### PR TITLE
allow styling marks and cursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,17 @@ works like
     Omnibar.listWords(<array of words>)
     Omnibar.html(<any html snippets>)
 
+### Styling
+
+Change the style of the link hints:
+
+    Hints.style('border: solid 3px #552a48; color:#efe1eb; background: initial; background-color: #552a48;');
+
+Change the style of the search marks and cursor:
+
+    Visual.style('marks', 'background-color: #89a1e2;');
+    Visual.style('cursor', 'background-color: #9065b7;');
+
 ## Build
 
     npm install

--- a/content_scripts/visual.js
+++ b/content_scripts/visual.js
@@ -1,5 +1,5 @@
 var Visual = (function(mode) {
-    var self = $.extend({name: "Visual", eventListeners: {}}, mode);
+    var self = $.extend({name: "Visual", eventListeners: {}, _style: {}}, mode);
 
     self.addEventListener('keydown', function(event) {
         var updated = "";
@@ -459,5 +459,12 @@ var Visual = (function(mode) {
     runtime.on('visualEnter', function(message) {
         self.visualEnter(message.query);
     });
+
+    self.style = function (element, style) {
+        self._style[element] = style;
+
+        cursor.setAttribute('style', self._style.cursor || '');
+        mark_template.setAttribute('style', self._style.marks || '');
+    };
     return self;
 })(Mode);


### PR DESCRIPTION
this was a bit trickier since the elements aren't in the shadow DOM. The syntax is at least close to the `Hints` styling but I'm definitely open to suggestions there.