### PR TITLE
Update default.js

### DIFF
--- a/pages/default.js
+++ b/pages/default.js
@@ -193,6 +193,8 @@ map('<Ctrl-i>', 'I');
 mapkey('q', '#1Click on an Image or a button', 'Hints.create("img, button", Hints.dispatchMouseClick)');
 mapkey('E', '#3Go one tab left', 'RUNTIME("previousTab")');
 mapkey('R', '#3Go one tab right', 'RUNTIME("nextTab")');
+map('gt', 'E');
+map('gT', 'R');
 mapkey('<Alt-p>', '#3pin/unpin current tab', 'RUNTIME("togglePinTab")');
 mapkey('<Alt-m>', '#3mute/unmute current tab', 'RUNTIME("muteTab")');
 mapkey('B', '#4Go one tab history back', 'RUNTIME("historyTab", {backward: true})', {repeatIgnore: true});


### PR DESCRIPTION
Add vim-bindings for `map('gt', 'E');` and `map('gT', 'R');` to go to previous and next tab respectively.