### PR TITLE
Allow custom omnibar query with complex API

### DIFF
--- a/content_scripts/front.js
+++ b/content_scripts/front.js
@@ -75,11 +75,30 @@ var Front = (function() {
         frontendCommand(args);
     };
 
+    // var onOmniQuery;
+    // self.openOmniquery = function(args) {
+    //     onOmniQuery = function(query) {
+    //         httpRequest({
+    //             'url': args.url + query
+    //         }, function(res) {
+    //             var words = args.parseResult(res);
+
+    //             frontendCommand({
+    //                 action: 'updateOmnibarResult',
+    //                 words: words
+    //             });
+    //         });
+    //     };
+    //     self.openOmnibar(({type: "OmniQuery", extra: args.query}))
+    // };
+
+    //For more complicated API like Baidufanyi
+    
     var onOmniQuery;
     self.openOmniquery = function(args) {
         onOmniQuery = function(query) {
             httpRequest({
-                'url': args.url + query
+                'url': args.parseUrl(query)
             }, function(res) {
                 var words = args.parseResult(res);
 

--- a/content_scripts/front.js
+++ b/content_scripts/front.js
@@ -74,25 +74,6 @@ var Front = (function() {
         args.action = 'openOmnibar';
         frontendCommand(args);
     };
-
-    // var onOmniQuery;
-    // self.openOmniquery = function(args) {
-    //     onOmniQuery = function(query) {
-    //         httpRequest({
-    //             'url': args.url + query
-    //         }, function(res) {
-    //             var words = args.parseResult(res);
-
-    //             frontendCommand({
-    //                 action: 'updateOmnibarResult',
-    //                 words: words
-    //             });
-    //         });
-    //     };
-    //     self.openOmnibar(({type: "OmniQuery", extra: args.query}))
-    // };
-
-    //For more complicated API like Baidufanyi
     
     var onOmniQuery;
     self.openOmniquery = function(args) {

--- a/content_scripts/front.js
+++ b/content_scripts/front.js
@@ -74,7 +74,7 @@ var Front = (function() {
         args.action = 'openOmnibar';
         frontendCommand(args);
     };
-    
+
     var onOmniQuery;
     self.openOmniquery = function(args) {
         onOmniQuery = function(query) {

--- a/pages/default.js
+++ b/pages/default.js
@@ -218,7 +218,6 @@ mapkey('Q', '#8Open omnibar for word translation', function() {
         }
     });
 });
-
 mapkey('b', '#8Open a bookmark', 'Front.openOmnibar(({type: "Bookmarks"}))');
 mapkey('ab', '#8Bookmark current page to selected folder', function() {
     var page = {

--- a/pages/default.js
+++ b/pages/default.js
@@ -204,9 +204,23 @@ mapkey('t', '#8Open an URL', 'Front.openOmnibar({type: "URLs", extra: "getAllSit
 mapkey('go', '#8Open an URL in current tab', 'Front.openOmnibar({type: "URLs", extra: "getAllSites", tabbed: false})');
 mapkey('ox', '#8Open recently closed URL', 'Front.openOmnibar({type: "URLs", extra: "getRecentlyClosed"})');
 mapkey('H', '#8Open opened URL in current tab', 'Front.openOmnibar({type: "URLs", extra: "getTabURLs"})');
+// mapkey('Q', '#8Open omnibar for word translation', function() {
+//     Front.openOmniquery({
+//         url: "https://api.shanbay.com/bdc/search/?word=",
+//         query: Visual.getWordUnderCursor(),
+//         parseResult: function(res) {
+//             var res = eval("a=" + res.text);
+//             return [res.data.definition || res.msg];
+//         }
+//     });
+// });
+
 mapkey('Q', '#8Open omnibar for word translation', function() {
     Front.openOmniquery({
-        url: "https://api.shanbay.com/bdc/search/?word=",
+        parseUrl: function(query){
+            var url = "https://api.shanbay.com/bdc/search/?word=";
+            return url + query;
+        },
         query: Visual.getWordUnderCursor(),
         parseResult: function(res) {
             var res = eval("a=" + res.text);
@@ -214,6 +228,7 @@ mapkey('Q', '#8Open omnibar for word translation', function() {
         }
     });
 });
+
 mapkey('b', '#8Open a bookmark', 'Front.openOmnibar(({type: "Bookmarks"}))');
 mapkey('ab', '#8Bookmark current page to selected folder', function() {
     var page = {

--- a/pages/default.js
+++ b/pages/default.js
@@ -204,17 +204,6 @@ mapkey('t', '#8Open an URL', 'Front.openOmnibar({type: "URLs", extra: "getAllSit
 mapkey('go', '#8Open an URL in current tab', 'Front.openOmnibar({type: "URLs", extra: "getAllSites", tabbed: false})');
 mapkey('ox', '#8Open recently closed URL', 'Front.openOmnibar({type: "URLs", extra: "getRecentlyClosed"})');
 mapkey('H', '#8Open opened URL in current tab', 'Front.openOmnibar({type: "URLs", extra: "getTabURLs"})');
-// mapkey('Q', '#8Open omnibar for word translation', function() {
-//     Front.openOmniquery({
-//         url: "https://api.shanbay.com/bdc/search/?word=",
-//         query: Visual.getWordUnderCursor(),
-//         parseResult: function(res) {
-//             var res = eval("a=" + res.text);
-//             return [res.data.definition || res.msg];
-//         }
-//     });
-// });
-
 mapkey('Q', '#8Open omnibar for word translation', function() {
     Front.openOmniquery({
         parseUrl: function(query){


### PR DESCRIPTION
Hello brookhong, thank you for this brilliant extension!
Lately I find some dict/translate API like [api.fanyi.baidu.com/api/trans/product/apidoc](url) needs hash signature, To prevent the signature displaying in omnibar, passing a parse function may be a solution.

Then Baidu translate API can be set in settings like:

```javascript
    mapkey('ot',` '#8Open omnibar for text translation(Baidu)', function() {
    Front.openOmniquery({
        parseUrl: function(query){
            var url = "http://api.fanyi.baidu.com/api/trans/vip/translate?";
            ...
            var sign = MD5(appid + query + salt + key);
            ...
            return url + query + ... + sign;
        },
        query: Visual.getWordUnderCursor(),
        ...
    });
});