### PR TITLE
Rapid open multiple links (cf) while still be able to use j/k to move up down page? #135

### DIFF
--- a/content_scripts/hints.js
+++ b/content_scripts/hints.js
@@ -2,6 +2,7 @@ var Hints = (function(mode) {
     var self = $.extend({name: "Hints", eventListeners: {}}, mode);
 
     self.addEventListener('keydown', function(event) {
+        var updated = false;
         var hints = holder.find('>div');
         if (Mode.isSpecialKeyOf("<Esc>", event.sk_keyName)) {
             hide();
@@ -12,11 +13,23 @@ var Hints = (function(mode) {
         } else if (hints.length > 0) {
             if (event.keyCode === KeyboardUtils.keyCodes.backspace) {
                 prefix = prefix.substr(0, prefix.length - 1);
+                updated = true;
             } else {
                 var key = String.fromCharCode(event.keyCode);
-                if (key !== '') {
+                var casedKey = event.shiftKey ? key : key.toLowerCase();
+                
+                if (isMappedTo(casedKey, "j")) {
+                    Normal.scroll('down');
+                    self.create("", Hints.dispatchMouseClick, {tabbed: true, active: false, multipleHits: true});
+                    updated = true;
+                } else if (isMappedTo(casedKey, "k")) {
+                    Normal.scroll('up');
+                    self.create("", Hints.dispatchMouseClick, {tabbed: true, active: false, multipleHits: true});
+                    updated = true;
+                } else if (key !== '') {
                     if (self.characters.indexOf(key.toLowerCase()) !== -1) {
                         prefix = prefix + key;
+                        updated = true;
                     } else {
                         // quit hints if user presses non-hint key
                         hide();
@@ -25,7 +38,7 @@ var Hints = (function(mode) {
             }
             handleHint();
         }
-        event.sk_stopPropagation = true;
+        return "stopEventPropagation";
     });
     self.addEventListener('keyup', function(event) {
         if (event.keyCode === KeyboardUtils.keyCodes.space) {
@@ -41,6 +54,15 @@ var Hints = (function(mode) {
         style = $("<style></style>"),
         holder = $('<div id=sk_hints/>');
     self.characters = 'asdfgqwertzxcvb';
+
+    function isMappedTo(keyPressed, keyToCheck) {
+        var mappingKeyPressed = Normal.mappings.find(encodeKeystroke(keyPressed));
+        var mappingKeyToCheck = Normal.mappings.find(encodeKeystroke(keyToCheck));
+
+        return mappingKeyPressed 
+            && mappingKeyPressed.meta
+            && mappingKeyPressed.meta.word === mappingKeyToCheck.meta.word;
+    }
 
     function getZIndex(node) {
         var z = 0;

--- a/content_scripts/hints.js
+++ b/content_scripts/hints.js
@@ -1,5 +1,5 @@
 var Hints = (function(mode) {
-    var self = $.extend({name: "Hints", eventListeners: {}}, mode);
+    var self = $.extend({name: "Hints", eventListeners: {}, lastCreateAttrs: {}}, mode);
 
     self.addEventListener('keydown', function(event) {
         var hints = holder.find('>div');
@@ -18,10 +18,10 @@ var Hints = (function(mode) {
                 
                 if (isMappedTo(casedKey, "j")) {
                     Normal.scroll('down');
-                    self.create("", Hints.dispatchMouseClick, {tabbed: true, active: false, multipleHits: true});
+                    self.create("", Hints.dispatchMouseClick, self.lastCreateAttrs);
                 } else if (isMappedTo(casedKey, "k")) {
                     Normal.scroll('up');
-                    self.create("", Hints.dispatchMouseClick, {tabbed: true, active: false, multipleHits: true});
+                    self.create("", Hints.dispatchMouseClick, self.lastCreateAttrs);
                 } else if (key !== '') {
                     if (self.characters.indexOf(key.toLowerCase()) !== -1) {
                         prefix = prefix + key;
@@ -191,6 +191,9 @@ var Hints = (function(mode) {
     };
 
     self.create = function(cssSelector, onHintKey, attrs) {
+        // save last used attributes, which will be reused if the user scrolls while the hints are still open
+        self.lastCreateAttrs = attrs;
+
         attrs = $.extend({
             active: true,
             tabbed: false,

--- a/content_scripts/hints.js
+++ b/content_scripts/hints.js
@@ -2,7 +2,6 @@ var Hints = (function(mode) {
     var self = $.extend({name: "Hints", eventListeners: {}}, mode);
 
     self.addEventListener('keydown', function(event) {
-        var updated = false;
         var hints = holder.find('>div');
         if (Mode.isSpecialKeyOf("<Esc>", event.sk_keyName)) {
             hide();
@@ -13,7 +12,6 @@ var Hints = (function(mode) {
         } else if (hints.length > 0) {
             if (event.keyCode === KeyboardUtils.keyCodes.backspace) {
                 prefix = prefix.substr(0, prefix.length - 1);
-                updated = true;
             } else {
                 var key = String.fromCharCode(event.keyCode);
                 var casedKey = event.shiftKey ? key : key.toLowerCase();
@@ -21,15 +19,12 @@ var Hints = (function(mode) {
                 if (isMappedTo(casedKey, "j")) {
                     Normal.scroll('down');
                     self.create("", Hints.dispatchMouseClick, {tabbed: true, active: false, multipleHits: true});
-                    updated = true;
                 } else if (isMappedTo(casedKey, "k")) {
                     Normal.scroll('up');
                     self.create("", Hints.dispatchMouseClick, {tabbed: true, active: false, multipleHits: true});
-                    updated = true;
                 } else if (key !== '') {
                     if (self.characters.indexOf(key.toLowerCase()) !== -1) {
                         prefix = prefix + key;
-                        updated = true;
                     } else {
                         // quit hints if user presses non-hint key
                         hide();
@@ -38,7 +33,7 @@ var Hints = (function(mode) {
             }
             handleHint();
         }
-        return "stopEventPropagation";
+        event.sk_stopPropagation = true;
     });
     self.addEventListener('keyup', function(event) {
         if (event.keyCode === KeyboardUtils.keyCodes.space) {

--- a/content_scripts/hints.js
+++ b/content_scripts/hints.js
@@ -1,5 +1,5 @@
 var Hints = (function(mode) {
-    var self = $.extend({name: "Hints", eventListeners: {}, lastCreateAttrs: {}}, mode);
+    var self = $.extend({name: "Hints", eventListeners: {}}, mode);
 
     self.addEventListener('keydown', function(event) {
         var hints = holder.find('>div');
@@ -18,10 +18,10 @@ var Hints = (function(mode) {
                 
                 if (isMappedTo(casedKey, "j")) {
                     Normal.scroll('down');
-                    self.create("", Hints.dispatchMouseClick, self.lastCreateAttrs);
+                    self.create("", Hints.dispatchMouseClick, _lastCreateAttrs);
                 } else if (isMappedTo(casedKey, "k")) {
                     Normal.scroll('up');
-                    self.create("", Hints.dispatchMouseClick, self.lastCreateAttrs);
+                    self.create("", Hints.dispatchMouseClick, _lastCreateAttrs);
                 } else if (key !== '') {
                     if (self.characters.indexOf(key.toLowerCase()) !== -1) {
                         prefix = prefix + key;
@@ -49,6 +49,7 @@ var Hints = (function(mode) {
         style = $("<style></style>"),
         holder = $('<div id=sk_hints/>');
     self.characters = 'asdfgqwertzxcvb';
+    var _lastCreateAttrs = {};
 
     function isMappedTo(keyPressed, keyToCheck) {
         var mappingKeyPressed = Normal.mappings.find(encodeKeystroke(keyPressed));
@@ -56,6 +57,8 @@ var Hints = (function(mode) {
 
         return mappingKeyPressed 
             && mappingKeyPressed.meta
+            && mappingKeyToCheck
+            && mappingKeyToCheck.meta
             && mappingKeyPressed.meta.word === mappingKeyToCheck.meta.word;
     }
 
@@ -192,7 +195,7 @@ var Hints = (function(mode) {
 
     self.create = function(cssSelector, onHintKey, attrs) {
         // save last used attributes, which will be reused if the user scrolls while the hints are still open
-        self.lastCreateAttrs = attrs;
+        _lastCreateAttrs = attrs;
 
         attrs = $.extend({
             active: true,


### PR DESCRIPTION
https://cl.ly/3M2S3Q1D2w3V/Screen%20Recording%202017-01-15%20at%2002.27%20PM.mov

Allow scrolling while in hints mode. 

Main use case:

1. Press "cf" to open targeted hints mode.
2. Press "j" to scroll down. Notice the hints are regenerated.
3. Press a hint key combination to open in background.
4. Keep scrolling as long as desired. Press "escape" to exit. 

It should support remapped keys. I tested basic remappings, such that if a key was remapped to "j", that could be used as well.