### PR TITLE
Strike out already opened links

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,7 +519,7 @@ Change the style of the search marks and cursor:
 ## Build
 
     npm install
-    ./node_modules/gulp/bin/gulp.js
+    npm run build
 
 ## Credits
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -505,7 +505,7 @@ Surfingkeys默认使用[这个markdown分析器](https://github.com/chjj/marked)
 ## 编译
 
     npm install
-    ./node_modules/gulp/bin/gulp.js
+    npm run build
 
 ## Credits
 

--- a/content_scripts/content_scripts.css
+++ b/content_scripts/content_scripts.css
@@ -19,3 +19,7 @@ div.surfingkeys_cursor {
     border-radius: 3px;
     box-shadow: 0px 3px 7px 0px rgba(0, 0, 0, 0.3);
 }
+#sk_hints>div.sk_visited {
+    text-decoration: line-through;
+    font-style: italic;
+}

--- a/content_scripts/hints.js
+++ b/content_scripts/hints.js
@@ -40,6 +40,7 @@ var Hints = (function(mode) {
     });
 
     var prefix = "",
+        alreadyOpened = [],
         lastMouseTarget = null,
         behaviours = {
             mouseEvents: ['mouseover', 'mousedown', 'mouseup', 'click']
@@ -69,6 +70,7 @@ var Hints = (function(mode) {
             if (onhint) {
                 onhint.call(window, link, event);
                 if (behaviours.multipleHits) {
+                    alreadyOpened.push(prefix);
                     prefix = "";
                     refresh();
                 } else {
@@ -107,6 +109,9 @@ var Hints = (function(mode) {
         var hints = holder.find('>div');
         hints.each(function(i) {
             var label = $(this).data('label');
+            if (alreadyOpened.indexOf(label) >= 0) {
+                $(this).addClass('sk_visited');
+            }
             if (label.indexOf(prefix) === 0) {
                 $(this).html(label.substr(prefix.length)).css('opacity', 1);
                 $('<span/>').css('opacity', 0.2).html(prefix).prependTo(this);
@@ -126,6 +131,7 @@ var Hints = (function(mode) {
             mouseEvents: ['mouseover', 'mousedown', 'mouseup', 'click'],
             multipleHits: false
         };
+        alreadyOpened = [];
         holder.html("").remove();
         prefix = "";
         self.exit();

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   },
   "devDependencies": {},
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "gulp"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Sometimes, when i'm using (cf) mode to open several links, I usually forget which one I already opened. 

![screen](http://i.imgur.com/EQGB4Eu.jpg)

It's a small visual change for hints to tell difference between normal link and already opened. User is still able to open same link several time. 

