### PR TITLE
set StatusBar to not show by default

### DIFF
--- a/content_scripts/runtime.js
+++ b/content_scripts/runtime.js
@@ -15,8 +15,8 @@ var runtime = window.runtime || (function() {
             prevLinkRegex: /((<<|prev(ious)?)+)/i,
             hintAlign: "center",
             defaultSearchEngine: "g",
-            showModeStatus: true,
-            showProxyInStatusBar: true,
+            showModeStatus: false,
+            showProxyInStatusBar: false,
             richHintsForKeystroke: true,
             blacklistPattern: undefined,
             lastQuery: ""


### PR DESCRIPTION
I was very surprised to see this bar when Surfingkeys updated.

I thought there was a bug or something. It even stays on when Chrome is in fullscreen mode. I feel like it should be off by default and that people can turn it on in the settings if they want.