### PR TITLE
#285 fix emoji popup positioning

### DIFF
--- a/content_scripts/insert.js
+++ b/content_scripts/insert.js
@@ -175,7 +175,7 @@ var Insert = (function(mode) {
             if (emojiMatched === "") {
                 _emojiDiv.remove();
             } else {
-                _emojiDiv.html(emojiMatched).appendTo('body').show();
+                _emojiDiv.html(emojiMatched).hide().appendTo('body');
                 _emojiDiv.find('>div:nth(0)').addClass("selected");
                 var br;
                 if (isInput) {
@@ -187,7 +187,12 @@ var Insert = (function(mode) {
                 }
                 _emojiDiv.css('position', "fixed");
                 _emojiDiv.css('left', br.left);
-                _emojiDiv.css('top', br.top + br.height + 4 + document.body.scrollTop);
+                var top = br.top + br.height + 4;
+                if (top + _emojiDiv.height() > window.innerHeight) {
+                  top = top - _emojiDiv.height() - 24;
+                }
+                _emojiDiv.css('top', top);
+                _emojiDiv.show();
             }
         }
     }
@@ -201,7 +206,7 @@ var Insert = (function(mode) {
         mask.style.position = "absolute";
         mask.innerHTML = input.value;
         mask.style.left = (input.clientLeft + br.left) + "px";
-        mask.style.top = (input.clientTop + br.top) + "px";
+        mask.style.top = (input.clientTop + br.top + document.body.scrollTop) + "px";
         mask.style.color = "red";
         mask.style.overflow = "scroll";
         mask.style.visibility = "hidden";


### PR DESCRIPTION
This fixes several issues with positioning of emoji popup:

- `getCursorPixelPos` was giving a wrong position when the page was scrolled down (I was always wondering why I don't see emojis on github comments, this is why - the popup was simply above).
- to avoid jumping, the emoji popup is first hidden, and is shown only when the final position is set.
- when there is no space below to show emoji popup, it is shown above the input.

@brookhong please have a look :wink: 

This is where I recorded before / after: https://jsfiddle.net/muydno0s/2/

**BEFORE**
![emoji-pos-before](https://cloud.githubusercontent.com/assets/1177900/23808080/a981a64a-05c8-11e7-96d0-c3c49bff1d01.gif)

**AFTER**
![emoji-pos-after](https://cloud.githubusercontent.com/assets/1177900/23808083/ac86ba42-05c8-11e7-8d03-ea927d415a4d.gif)


