### PR TITLE
Briefly flash pressed link

### DIFF
--- a/content_scripts/hints.js
+++ b/content_scripts/hints.js
@@ -68,6 +68,7 @@ var Hints = (function(mode) {
             Normal.appendKeysForRepeat("Hints", prefix);
             var link = $(matches[0]).data('link');
             _onHintKey(link, event);
+            flashPressedLink(link);
             if (behaviours.multipleHits) {
                 prefix = "";
                 refresh();
@@ -78,6 +79,22 @@ var Hints = (function(mode) {
             hide();
         }
     }
+
+  function flashPressedLink(link) {
+    var rect = link.getBoundingClientRect();
+    var flashElem = document.createElement('div');
+    flashElem.style.position = 'absolute';
+    flashElem.style.boxShadow = '0px 0px 4px 2px #63b2ff';
+    flashElem.style.backgroundColor = 'transparent';
+    flashElem.style.left = (rect.left + document.body.scrollLeft) + 'px';
+    flashElem.style.top = (rect.top + document.body.scrollTop) + 'px';
+    flashElem.style.width = rect.width + 'px';
+    flashElem.style.height = rect.height + 'px';
+    flashElem.style.zIndex = 2140000000;
+    document.body.appendChild(flashElem);
+
+    setTimeout(function () { flashElem.remove(); }, 300);
+  }
 
     function dispatchMouseEvent(element, events) {
         events.forEach(function(eventName) {


### PR DESCRIPTION
I am missing visual feedback of what I've just clicked, a couple of times I pressed the wrong letter and _something_ was clicked, but I've no idea what. 

With this change a pressed link is briefly flashed, just enough to notice what was pressed.

![link-flash2](https://cloud.githubusercontent.com/assets/1177900/23817425/59396440-05f3-11e7-80d9-7bbf263a1ff1.gif)

