### PR TITLE
vmap for visual mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,8 @@ mapkey in visual mode
 
     imap(new_keystroke, old_keystroke, [domain_pattern], [new_annotation])
 
+    vmap(new_keystroke, old_keystroke, [domain_pattern], [new_annotation])
+
     cmap(new_keystroke, old_keystroke, [domain_pattern], [new_annotation])
 
 | parameter  | explanation |

--- a/README_CN.md
+++ b/README_CN.md
@@ -493,6 +493,8 @@ Surfingkeys默认使用[这个markdown分析器](https://github.com/chjj/marked)
 
     imap(new_keystroke, old_keystroke, [domain_pattern], [new_annotation])
 
+    vmap(new_keystroke, old_keystroke, [domain_pattern], [new_annotation])
+
     cmap(new_keystroke, old_keystroke, [domain_pattern], [new_annotation])
 
 | 参数  | 含义 |

--- a/content_scripts/content_scripts.js
+++ b/content_scripts/content_scripts.js
@@ -254,6 +254,19 @@ function cmap(new_keystroke, old_keystroke, domain, new_annotation) {
     }
 }
 
+function vmap(new_keystroke, old_keystroke, domain, new_annotation) {
+    shouldWorkFor(domain, function() {
+        var old_map = Visual.mappings.find(encodeKeystroke(old_keystroke));
+        if (old_map) {
+            var nks = encodeKeystroke(new_keystroke);
+            Visual.mappings.remove(nks);
+            // meta.word need to be new
+            var meta = $.extend({}, old_map.meta);
+            Visual.mappings.add(nks, meta);
+        }
+    });
+}
+
 function vunmap(keystroke, domain) {
     shouldWorkFor(domain, function() {
         Visual.mappings.remove(encodeKeystroke(keystroke));


### PR DESCRIPTION
@brookhong thank you very much for this extension, just found it today and it's an amazing replacement for cVim!!

I use [Colemak keyboard layout](https://colemak.com/), and I hit a limitation because `vmap` is not defined, this PR adds the `vmap` function that follows what `imap` does.

@brookhong I would also love it if you could take a look at my [.surfingkeys.js](https://github.com/kalbasit/dotfiles/blob/master/.surfingkeys.js.erb) and let me know if there's a better way to do it.