### PR TITLE
Holding shift while typing hint opens hint in new tab

### DIFF
--- a/content_scripts/hints.js
+++ b/content_scripts/hints.js
@@ -17,7 +17,7 @@ var Hints = (function(mode) {
             } else {
                 var key = event.sk_keyName;
                 if (isCapital(key)) {
-                    shiftKey = true
+                    shiftKey = true;
                 }
                 if (key !== '') {
                     if (self.characters.toLowerCase().indexOf(key.toLowerCase()) !== -1) {
@@ -58,7 +58,7 @@ var Hints = (function(mode) {
 
     function isCapital(key) {
         return key === key.toUpperCase() &&
-               key !== key.toLowerCase() // in case key is a symbol or special character
+               key !== key.toLowerCase(); // in case key is a symbol or special character
     }
 
     function getZIndex(node) {

--- a/content_scripts/hints.js
+++ b/content_scripts/hints.js
@@ -16,8 +16,11 @@ var Hints = (function(mode) {
                 handleHint();
             } else {
                 var key = event.sk_keyName;
+                if (isCapital(key)) {
+                    shiftKey = true
+                }
                 if (key !== '') {
-                    if (self.characters.indexOf(key) !== -1) {
+                    if (self.characters.toLowerCase().indexOf(key.toLowerCase()) !== -1) {
                         prefix = prefix + key.toUpperCase();
                         handleHint();
                     } else {
@@ -45,12 +48,18 @@ var Hints = (function(mode) {
             mouseEvents: ['mouseover', 'mousedown', 'mouseup', 'click']
         },
         style = $("<style></style>"),
-        holder = $('<div id=sk_hints style="display: block; opacity: 1;"/>');
+        holder = $('<div id=sk_hints style="display: block; opacity: 1;"/>'),
+        shiftKey = false;
     self.characters = 'asdfgqwertzxcvb';
     self.scrollKeys = '0jkhlG$';
     var _lastCreateAttrs = {},
         _onHintKey = self.dispatchMouseClick,
         _cssSelector = "";
+
+    function isCapital(key) {
+        return key === key.toUpperCase() &&
+               key !== key.toLowerCase() // in case key is a symbol or special character
+    }
 
     function getZIndex(node) {
         var z = 0;
@@ -82,8 +91,8 @@ var Hints = (function(mode) {
     function dispatchMouseEvent(element, events) {
         events.forEach(function(eventName) {
             var event = document.createEvent('MouseEvents');
-            event.initMouseEvent(eventName, true, true, window, 1, 0, 0, 0, 0, false,
-                false, false, false, 0, null);
+            event.initMouseEvent(eventName, true, true, window, 1, 0, 0, 0, 0, shiftKey,
+                false, shiftKey, false, 0, null);
             element.dispatchEvent(event);
         });
         lastMouseTarget = element;
@@ -115,6 +124,7 @@ var Hints = (function(mode) {
         };
         holder.html("").remove();
         prefix = "";
+        shiftKey = false;
         self.exit();
     }
 

--- a/content_scripts/hints.js
+++ b/content_scripts/hints.js
@@ -91,8 +91,9 @@ var Hints = (function(mode) {
     function dispatchMouseEvent(element, events) {
         events.forEach(function(eventName) {
             var event = document.createEvent('MouseEvents');
-            event.initMouseEvent(eventName, true, true, window, 1, 0, 0, 0, 0, shiftKey,
-                false, shiftKey, false, 0, null);
+            var mouseButton = (shiftKey === true) ? 1 : 0;
+            event.initMouseEvent(eventName, true, true, window, 1, 0, 0, 0, 0, false,
+                false, false, false, mouseButton, null);
             element.dispatchEvent(event);
         });
         lastMouseTarget = element;


### PR DESCRIPTION
If any part of a hint is typed as uppercase (i.e. with the shift key held down), open the hint in a new tab.

Fixes #392

My rationale for this change:

This functionality was described by @brookhong in issue #4, in reference to "open[ing] the selected hint in a new tab":

> just hold shift when you press the hint chars, actually you don't need to hold shift from the beginning. Holding shift at the last char is good to go.

This change should behave as described above.

This is also the standard behavior for other Chrome Vim extensions like cVim and Vimium, implying that it's a generally well accepted behavior.