### PR TITLE
SearchEngine auto-completion suggestions: Prevent extra HTTP requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -620,7 +620,7 @@ For example,
 | settings.focusOnSaved | true | Whether to focus text input after quiting from vim editor. |
 | settings.omnibarMaxResults | 10 | How many results will be listed out each page for Omnibar. |
 | settings.omnibarPosition | "middle" | Where to position Omnibar. ["middle", "bottom"] |
-| settings.omnibarSuggestionTimeout | 200 | Timeout duration before Omnibar suggestion URLs are queried in milliseconds. Helps prevent unnecessary HTTP requests and/or API rate-limiting. |
+| settings.omnibarSuggestionTimeout | 200 | Timeout duration before Omnibar suggestion URLs are queried, in milliseconds. Helps prevent unnecessary HTTP requests and/or API rate-limiting. |
 | settings.focusFirstCandidate | false | Whether to focus first candidate of matched result in Omnibar. |
 | settings.tabsThreshold | 9 | When total of opened tabs exceeds the number, Omnibar will be used for choosing tabs. |
 | settings.hintsThreshold | 10000 | When total of regular clickable elements (a, button, select, input, textarea) exceeds this number, Surfingkeys will not show hints for other elements that are clickable. |

--- a/README.md
+++ b/README.md
@@ -620,7 +620,7 @@ For example,
 | settings.focusOnSaved | true | Whether to focus text input after quiting from vim editor. |
 | settings.omnibarMaxResults | 10 | How many results will be listed out each page for Omnibar. |
 | settings.omnibarPosition | "middle" | Where to position Omnibar. ["middle", "bottom"] |
-| settings.omnibarSuggestionTimeout | 200 | Timeout duration before Omnibar suggestion URLs are queried, in milliseconds. Helps prevent unnecessary HTTP requests and/or API rate-limiting. |
+| settings.omnibarSuggestionTimeout | 200 | Timeout duration before Omnibar suggestion URLs are queried, in milliseconds. Helps prevent unnecessary HTTP requests and API rate-limiting. |
 | settings.focusFirstCandidate | false | Whether to focus first candidate of matched result in Omnibar. |
 | settings.tabsThreshold | 9 | When total of opened tabs exceeds the number, Omnibar will be used for choosing tabs. |
 | settings.hintsThreshold | 10000 | When total of regular clickable elements (a, button, select, input, textarea) exceeds this number, Surfingkeys will not show hints for other elements that are clickable. |

--- a/README.md
+++ b/README.md
@@ -620,6 +620,7 @@ For example,
 | settings.focusOnSaved | true | Whether to focus text input after quiting from vim editor. |
 | settings.omnibarMaxResults | 10 | How many results will be listed out each page for Omnibar. |
 | settings.omnibarPosition | "middle" | Where to position Omnibar. ["middle", "bottom"] |
+| settings.omnibarSuggestionTimeout | 200 | Timeout duration before Omnibar suggestion URLs are queried in milliseconds. Helps prevent unnecessary HTTP requests and/or API rate-limiting. |
 | settings.focusFirstCandidate | false | Whether to focus first candidate of matched result in Omnibar. |
 | settings.tabsThreshold | 9 | When total of opened tabs exceeds the number, Omnibar will be used for choosing tabs. |
 | settings.hintsThreshold | 10000 | When total of regular clickable elements (a, button, select, input, textarea) exceeds this number, Surfingkeys will not show hints for other elements that are clickable. |

--- a/content_scripts/runtime.js
+++ b/content_scripts/runtime.js
@@ -7,6 +7,7 @@ var runtime = window.runtime || (function() {
             focusOnSaved: true,
             omnibarMaxResults: 10,
             omnibarPosition: "middle",
+            omnibarSuggestionTimeout: 200,
             tabsThreshold: 9,
             hintsThreshold: 10000,
             smoothScroll: true,

--- a/pages/omnibar.js
+++ b/pages/omnibar.js
@@ -956,7 +956,7 @@ var SearchEngine = (function() {
             return;
         }
         var val = Omnibar.input.val();
-        if(_pendingRequest) {
+        if (_pendingRequest) {
             clearTimeout(_pendingRequest);
             _pendingRequest = undefined;
         }

--- a/pages/omnibar.js
+++ b/pages/omnibar.js
@@ -916,6 +916,8 @@ var SearchEngine = (function() {
     var self = {};
     self.aliases = {};
 
+    var _pendingRequest = undefined; // timeout ID
+
     self.onOpen = function(arg) {
         $.extend(self, self.aliases[arg]);
         var q = Omnibar.input.val();
@@ -950,18 +952,26 @@ var SearchEngine = (function() {
         return this.activeTab;
     };
     self.onInput = function() {
-        if (self.suggestionURL) {
-            var val = Omnibar.input.val();
+        if (!self.suggestionURL || typeof(self.listSuggestion) !== "function") {
+            return;
+        }
+        var val = Omnibar.input.val();
+        if(_pendingRequest) {
+            clearTimeout(_pendingRequest);
+            _pendingRequest = undefined;
+        }
+        // Set a timeout before the request is dispatched so that it can be canceled if necessary.
+        // This helps prevent rate-limits when typing a long query.
+        // E.g. github.com's API rate-limits after only 10 unauthenticated requests.
+        _pendingRequest = setTimeout(function() {
             runtime.command({
                 action: 'request',
                 method: 'get',
                 url: self.suggestionURL + val
             }, function(resp) {
-                if (typeof(self.listSuggestion === "function")) {
-                    self.listSuggestion(resp);
-                }
+                self.listSuggestion(resp);
             });
-        }
+        }, 200);
     };
     return self;
 })();

--- a/pages/omnibar.js
+++ b/pages/omnibar.js
@@ -971,7 +971,7 @@ var SearchEngine = (function() {
             }, function(resp) {
                 self.listSuggestion(resp);
             });
-        }, 200);
+        }, runtime.conf.omnibarSuggestionTimeout);
     };
     return self;
 })();


### PR DESCRIPTION
Previously, when entering text into an OmniBar SearchEngine with a suggestion URL, an HTTP request would be dispatched for each keystroke. When typing long queries, this could lead to rate-limiting, extra network traffic, and is unfriendly to API servers.

---

I've updated the SearchEngine suggestion logic to use a timeout of 200ms
before dispatching an HTTP request. If another keystroke occurs before
this 200ms timeout, the previous request is canceled.

Example Result - When typing "testing" into a SearchEngine dialog with less than 200ms delay between keystrokes:

Old: 7 HTTP requests are dispatched
New: 1 HTTP request is dispatched

Note: It may be desirable to make the timeout duration configurable.
Currently it's hard-coded as 200ms.

---

This has proven to be very beneficial for me.

I've added a lot of custom searchAliasX's to my configuration, and many APIs (including GitHub's) will rate limit you very quickly using the old code.

Also, if an API is very slow to respond, it can cause odd behavior in the OmniBar when several requests finish at once or out of order.