### PR TITLE
Use %s inside suggestionURL as placeholder

### DIFF
--- a/pages/omnibar.js
+++ b/pages/omnibar.js
@@ -950,9 +950,9 @@ var SearchEngine = (function() {
 
     function formatURL(url, query) {
         if (url.indexOf("%s") !== -1) {
-            return url.replace("%s", query)
+            return url.replace("%s", query);
         }
-        return url + query
+        return url + query;
     }
 
     self.onOpen = function(arg) {

--- a/pages/omnibar.js
+++ b/pages/omnibar.js
@@ -948,6 +948,13 @@ var SearchEngine = (function() {
 
     var _pendingRequest = undefined; // timeout ID
 
+    function formatURL(url, query) {
+        if (url.indexOf("%s") !== -1) {
+            return url.replace("%s", query)
+        }
+        return url + query
+    }
+
     self.onOpen = function(arg) {
         $.extend(self, self.aliases[arg]);
         var q = Omnibar.input.val();
@@ -997,7 +1004,7 @@ var SearchEngine = (function() {
             runtime.command({
                 action: 'request',
                 method: 'get',
-                url: self.suggestionURL + val
+                url: formatURL(self.suggestionURL, val)
             }, function(resp) {
                 var resp = self.listSuggestion(resp);
                 if (Array.isArray(resp)) {


### PR DESCRIPTION
Added the option to use `%s` as a placeholder within a SearchEngine suggestionURL, which enables the suggestion value to be inserted anywhere within the URL string, rather than just at the very end.

If `%s` is found anywhere within the suggestionURL, the first occurrence of `%s` is replaced with the search term.

If `%s` is **not** found anywhere within the suggestionURL, the search term is appended to the end as prior.

This allows suggestionURLs like the following:

	My main use case:
	- https://api.datamuse.com/words?md=d&sp=%s*

	Other examples:
	- https://www.foobar.com/search?q=%s&type=v
	- https://www.barqux.com/search/%s.json
	- https://www.fizzbuzz.com/keywords/%s/page/1

This should not cause any issues for existing user configurations unless someone is using a suggestionURL which happens to contain `%s` somewhere within it, which I would expect to 
be relatively rare, for example:

	- https://www.fizzbuzz.com/query?foo=%s&q=

However, the user would be able to overcome this issue by substituting `%25s`, where `%25` is the URL-encoding of the `%` character:

	- https://www.fizzbuzz.com/query?foo=%25s&q=
 