### PR TITLE
SearchEngine Omnibar input value should be URIEncoded

### DIFF
--- a/pages/omnibar.js
+++ b/pages/omnibar.js
@@ -977,7 +977,7 @@ var SearchEngine = (function() {
     };
     self.onEnter = function() {
         var fi = Omnibar.resultsDiv.find('li.focused');
-        var url = fi.data('url') || constructSearchURL(self.url, (fi.data('query') || Omnibar.input.val()) );
+        var url = fi.data('url') || constructSearchURL(self.url, (fi.data('query') || encodeURIComponent(Omnibar.input.val())) );
         runtime.command({
             action: "openLink",
             tab: {
@@ -992,7 +992,7 @@ var SearchEngine = (function() {
         if (!self.suggestionURL || typeof(self.listSuggestion) !== "function") {
             return;
         }
-        var val = Omnibar.input.val();
+        var val = encodeURIComponent(Omnibar.input.val());
         if (_pendingRequest) {
             clearTimeout(_pendingRequest);
             _pendingRequest = undefined;


### PR DESCRIPTION
Since the Omnibar SearchEngine input value is a user-provided string, it should be encoded with encodeURIComponent prior to being handled in a URL.

Previously, if a user entered a character such as`#`, it would be interpreted literally inside the URL as a fragment identifier character rather than as a normal `#` character. [More information on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent). 

The old behavior could have security implications.

_P.S. Sorry if I'm submitting too many PRs, I love this extension and use it a lot, so when I run into problems I usually try to fix them and figure I might as well submit the changes upstream :smile:_ 