### PR TITLE
Options page example link updated to be not 404

### DIFF
--- a/pages/options.html
+++ b/pages/options.html
@@ -48,7 +48,7 @@ textarea {
         <label for="localPath">Load settings from:</label>
         <input type="text" value="" id="localPath" name="localPath" size=72>
         <span class=infoPointer for=localPathHelp>?</span>
-        <div class=info id='localPathHelp'>You can load settings from URLs in scheme http/https, for example, <a href="https://gist.githubusercontent.com/brookhong/982147a8085481db9f45/raw/0699039b5beaeeaf10a52bb95c9be25fb3d6afd1/gistfile1.txt">https://gist.githubusercontent.com/brookhong/982147a8085481db9f45/raw/0699039b5beaeeaf10a52bb95c9be25fb3d6afd1/gistfile1.txt</a>. If you want to load settings from local file, please check <b>Allow access to file URLs</b> in <a href="chrome://extensions/">chrome://extensions/</a> for this extension, and specify the full path of your settings file, for example, /home/brook/.surfingkeys.js.</div>
+        <div class=info id='localPathHelp'>You can load settings from URLs in scheme http/https, for example, <a href="https://gist.githubusercontent.com/brookhong/755982e0014004207849f6e357af56f3/raw/0404596d1b32f7cc30eeb0615d0e42d0822a2232/gistfile1.txt">https://gist.githubusercontent.com/brookhong/755982e0014004207849f6e357af56f3/raw/0404596d1b32f7cc30eeb0615d0e42d0822a2232/gistfile1.txt</a>. If you want to load settings from local file, please check <b>Allow access to file URLs</b> in <a href="chrome://extensions/">chrome://extensions/</a> for this extension, and specify the full path of your settings file, for example, /home/brook/.surfingkeys.js.</div>
         <div id="save_container">
             <a href="#" id='showDefaultSettings'>Default mappings</a>
             <a href="https://github.com/brookhong/Surfingkeys/issues" target="_blank">Report issues</a>


### PR DESCRIPTION
#### Issue
`options.html` has an example link to a gist, which is not working (HTTP 404):
https://gist.githubusercontent.com/brookhong/982147a8085481db9f45/raw/0699039b5beaeeaf10a52bb95c9be25fb3d6afd1/gistfile1.txt

#### Proposed fix
I grabbed an existing, working link. There is content. I adapted from the previous file name to the current link.

https://gist.githubusercontent.com/brookhong/755982e0014004207849f6e357af56f3/raw/0404596d1b32f7cc30eeb0615d0e42d0822a2232/gistfile1.txt