### PR TITLE
Browser-wide tab navigation

### DIFF
--- a/background.js
+++ b/background.js
@@ -456,6 +456,7 @@ var ChromeService = (function() {
                     var tab = tabs[0];
                     var index = (command === 'previousTab') ? tab.index - 1 : tab.index + 1;
                     chrome.tabs.query({ windowId: tab.windowId }, function(tabs) {
+                        index = ((index % tabs.length) + tabs.length) % tabs.length;
                         chrome.tabs.update(tabs[index].id, { active: true });
                     });
                 });

--- a/background.js
+++ b/background.js
@@ -450,6 +450,16 @@ var ChromeService = (function() {
             case 'restartext':
                 chrome.runtime.reload();
                 break;
+            case 'previousTab':
+            case 'nextTab':
+                chrome.tabs.query({ active: true, currentWindow: true }, function(tabs) {
+                    var tab = tabs[0];
+                    var index = (command === 'previousTab') ? tab.index - 1 : tab.index + 1;
+                    chrome.tabs.query({ windowId: tab.windowId }, function(tabs) {
+                        chrome.tabs.update(tabs[index].id, { active: true });
+                    });
+                });
+                break;
             case 'proxyThis':
                 chrome.tabs.query({
                     currentWindow: true,

--- a/background.js
+++ b/background.js
@@ -461,6 +461,11 @@ var ChromeService = (function() {
                     });
                 });
                 break;
+            case 'closeTab':
+                chrome.tabs.query({ active: true, currentWindow: true }, function(tabs) {
+                    chrome.tabs.remove(tabs[0].id);
+                });
+                break;
             case 'proxyThis':
                 chrome.tabs.query({
                     currentWindow: true,

--- a/manifest.json
+++ b/manifest.json
@@ -13,6 +13,12 @@
         "restartext": {
             "description": "Restart this extenstion."
         },
+        "previousTab": {
+            "description": "Go to the previous tab."
+        },
+        "nextTab": {
+            "description": "Go to the next tab."
+        },
         "proxyThis": {
             "description": "Toggle current site in autoproxy_hosts."
         }

--- a/manifest.json
+++ b/manifest.json
@@ -19,6 +19,9 @@
         "nextTab": {
             "description": "Go to the next tab."
         },
+        "closeTab": {
+            "description": "Close the current tab."
+        },
         "proxyThis": {
             "description": "Toggle current site in autoproxy_hosts."
         }


### PR DESCRIPTION
This adds the ability to have tab navigation that works on every page, including chrome pages.

You register your desired keys by clicking "Keyboard shortcuts" at the bottom of `chrome://extensions/`.