### PR TITLE
Implement global hotkey for tab selector

### DIFF
--- a/background.js
+++ b/background.js
@@ -468,6 +468,18 @@ var ChromeService = (function() {
                     chrome.tabs.remove(tabs[0].id);
                 });
                 break;
+            case 'chooseTab':
+                chrome.tabs.query({
+                    currentWindow: true,
+                    active: true
+                }, function(resp) {
+                    var cur = resp[0].id;
+                    chrome.tabs.sendMessage(cur, {
+                        target: 'content_runtime',
+                        subject: 'chooseTab'
+                    });
+                });
+                break;
             case 'proxyThis':
                 chrome.tabs.query({
                     currentWindow: true,

--- a/content_scripts/front.js
+++ b/content_scripts/front.js
@@ -290,6 +290,10 @@ var Front = (function() {
         });
     };
 
+    runtime.runtime_handlers['chooseTab'] = function(msg, sender, response) {
+        self.chooseTab();
+    };
+
     runtime.runtime_handlers['focusFrame'] = function(msg, sender, response) {
         if (msg.frameId === window.frameId) {
             window.focus();

--- a/manifest.json
+++ b/manifest.json
@@ -22,6 +22,9 @@
         "closeTab": {
             "description": "Close the current tab."
         },
+        "chooseTab": {
+            "description": "Invoke tab selector."
+        },
         "proxyThis": {
             "description": "Toggle current site in autoproxy_hosts."
         }


### PR DESCRIPTION
Certain websites (e.g. Gmail, Twitter, Remember the Milk, etc.) have their own keybindings which are kinda okay to use. However, if you turn off Surfingkey on them, you end up having no means of switching a tab via Surfingkey hotkey which is pretty annoying. So to get around this I had lots of following code in my config:
```
if (window.location.origin === "https://www.gmail.com") {
// lots of unmap commands. Basically everything but the key to switch tab
}
```
...which is of course a bit annoying and not very sustainable.
So I've added a global hotkey setting which would let you set a global hotkey to invoke the awesome tab selector regardless of Surfingkey being active on current page.
It's literally the first time I am commiting to a chrome extension, so let me know if it's hacky or anything, but I think I got it right.
