### PR TITLE
respect CaseSensitive settings  and keep last-used bookmark folder keyword in bookmark omnibar

### DIFF
--- a/pages/omnibar.js
+++ b/pages/omnibar.js
@@ -740,6 +740,19 @@ var AddBookmark = (function() {
                     Omnibar.resultsDiv.find('li.focused').removeClass('focused');
                     Omnibar.focusItem(`li[folder=${b.parentId}]`);
                 }
+
+                //restore the last used bookmark folder input
+                var lastBookmarkFolder = localStorage.getItem("surfingkeys.lastAddedBookmark");
+                if (lastBookmarkFolder) {
+                  Omnibar.input.val(lastBookmarkFolder);
+
+                  //make the input selected, so if user don't want to use it,
+                  //just input to overwrite the previous value
+                  Omnibar.input.select();
+
+                  // trigger omnibar input matching 
+                  self.onInput();
+                }
             });
         });
     };
@@ -793,6 +806,7 @@ var AddBookmark = (function() {
         }, function(response) {
             Front.showBanner("Bookmark created at {0}.".format(folderName), 3000);
         });
+        localStorage.setItem("surfingkeys.lastAddedBookmark", Omnibar.input.val()); 
         return true;
     };
 

--- a/pages/omnibar.js
+++ b/pages/omnibar.js
@@ -799,7 +799,10 @@ var AddBookmark = (function() {
     self.onInput = function() {
         var query = Omnibar.input.val();
         var matches = folders.filter(function(b) {
-            return b.title.indexOf(query) !== -1;
+            if (runtime.conf.caseSensitive)
+              return b.title.indexOf(query) !== -1;
+            else
+              return b.title.toLowerCase().indexOf(query.toLowerCase()) !== -1;
         });
         Omnibar.listResults(matches, function(f) {
             return $('<li/>').attr('folder', f.id).html("▷ {0}".format(f.title));


### PR DESCRIPTION
there are two improvements: 

1. respect config 'runtime.conf.caseSensitive' when comparing user's input against bookmark folder in omnibar

2. keep the last-used bookmark folder keyword so if user want to add bookmarks to the same folder, he doesn't need to input the keyword again, just like the default adding bookmark behavior in Chrome.

Thanks for making this great extension! It is just what I am looking for. I had switched from Vimium after using Vimium for 5+ years.