### PR TITLE
Fix pinning/unpinning not working in Firefox

### DIFF
--- a/background.js
+++ b/background.js
@@ -612,7 +612,8 @@ var ChromeService = (function() {
         });
     };
     self.togglePinTab = function(message, sender, sendResponse) {
-        chrome.tabs.getSelected(null, function(tab) {
+        chrome.tabs.query({currentWindow: true, active: true}, function(tabs) {
+            var tab = tabs[0];
             return chrome.tabs.update(tab.id, {
                 pinned: !tab.pinned
             });


### PR DESCRIPTION
`tabs.getSelected` has been deprecated since Chrome 33
(https://developer.chrome.com/extensions/tabs#method-getSelected) and
was never implemented when Firefox moved to WebExtensions
(https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/tabs/getSelected).
The recommended way to get the current tab is with `tabs.query` now.

Fixes one of the issues in #621