### PR TITLE
Fix #630 <Tab> not cycling between inputs when enableAutoFocus is false

### DIFF
--- a/content_scripts/normal.js
+++ b/content_scripts/normal.js
@@ -305,7 +305,6 @@ var Normal = (function(mode) {
         } else if (event.sk_keyName.length) {
             Mode.handleMapKey.call(self, event);
         }
-        self.passFocus(runtime.conf.enableAutoFocus);
     });
     self.addEventListener('blur', function(event) {
         keyHeld = 0;


### PR DESCRIPTION
Although there was code to allow `<Tab>` to focus on the next input, it
was always overridden later in the `keydown` event handler by the value
of `settings.enableAutoFocus`.