### PR TITLE
Open new tabs in current Container in Firefox

### DIFF
--- a/background.js
+++ b/background.js
@@ -912,7 +912,8 @@ var ChromeService = (function() {
                 url: url,
                 active: message.tab.active,
                 index: newTabPosition,
-                pinned: message.tab.pinned
+                pinned: message.tab.pinned,
+                openerTabId: sender.tab.id
             }, function(tab) {
                 if (message.scrollLeft || message.scrollTop) {
                     tabMessages[tab.id] = {


### PR DESCRIPTION
Just another small change to add some support for [Firefox Containers](https://support.mozilla.org/en-US/kb/containers), so that links and things opened in new tabs use the origin tab's container. Currently new tabs are always opened without being placed in a container.

Thanks for the great extension and porting it to Firefox also!