### PR TITLE
Fix unnecessary scrolling when cursor is too small in Firefox

### DIFF
--- a/content_scripts/utils.js
+++ b/content_scripts/utils.js
@@ -69,20 +69,20 @@ function reportIssue(title, description) {
     Front.showPopup(error);
 }
 
-function scrollIntoViewIfNeeded(elm) {
+function scrollIntoViewIfNeeded(elm, ignoreSize) {
     if (elm.scrollIntoViewIfNeeded) {
         elm.scrollIntoViewIfNeeded();
-    } else if (!isElementPartiallyInViewport(elm)) {
+    } else if (!isElementPartiallyInViewport(elm, ignoreSize)) {
         elm.scrollIntoView();
     }
 }
 
-function isElementPartiallyInViewport(el) {
+function isElementPartiallyInViewport(el, ignoreSize) {
     var rect = el.getBoundingClientRect();
     var windowHeight = (window.innerHeight || document.documentElement.clientHeight);
     var windowWidth = (window.innerWidth || document.documentElement.clientWidth);
 
-    return rect.width > 4 && rect.height > 4
+    return (ignoreSize || (rect.width > 4 && rect.height > 4))
         && (rect.top <= windowHeight) && (rect.bottom >= 0)
         && (rect.left <= windowWidth) && (rect.right >= 0);
 }

--- a/content_scripts/visual.js
+++ b/content_scripts/visual.js
@@ -450,7 +450,7 @@ var Visual = (function(mode) {
 
             // set content of cursor to enable scrollIntoViewIfNeeded
             $(cursor).html(ch);
-            scrollIntoViewIfNeeded(cursor);
+            scrollIntoViewIfNeeded(cursor, true);
         }
     };
     self.getCursorPixelPos = function () {


### PR DESCRIPTION
Since Firefox doesn't implement `scrollIntoViewIfNeeded`,
`isElementPartiallyInViewport` is used which considers elements smaller
than 4x4 pixels not visible. Thus when the cursor in visual mode
contains text smaller than that (e.g. the letter "i"), `scrollIntoView`
will always be called even if the cursor is currently visible.

This adds an optional `ignoreSize` argument to `scrollIntoViewIfNeeded`
to ignore the element size and is only used for the cursor.

Fixes another issue in #621