### PR TITLE
Use topmost rect instead of bounding rect for hint placement

### DIFF
--- a/content_scripts/hints.js
+++ b/content_scripts/hints.js
@@ -247,22 +247,18 @@ var Hints = (function(mode) {
         var bof = self.coordinate();
         $("<style></style>").html("#sk_hints>div{" + _styleForClick + "}").appendTo(holder);
         elements.each(function(i) {
-            var pos = $(this).offset(),
+            var pos = this.getClientRects()[0],
                 z = getZIndex(this);
-            if (pos.top === 0 && pos.left === 0) {
-                // work around for svg elements, https://github.com/jquery/jquery/issues/3182
-                pos = this.getBoundingClientRect();
-            }
-            var left, width = Math.min($(this).width(), window.innerWidth);
+            var left, width = Math.min(pos.width, window.innerWidth);
             if (runtime.conf.hintAlign === "right") {
-                left = pos.left - bof.left + width / 2;
+                left = pos.left - bof.left + width;
             } else if (runtime.conf.hintAlign === "left") {
                 left = pos.left - bof.left;
             } else {
                 left = pos.left - bof.left + width / 2;
             }
-            left = Math.max(left, 0);
-            var link = $('<div/>').css('top', Math.max(pos.top - bof.top, 0)).css('left', left)
+            left = Math.max(left + window.pageXOffset, 0);
+            var link = $('<div/>').css('top', Math.max(pos.top + window.pageYOffset - bof.top, 0)).css('left', left)
                 .css('z-index', z + 9999)
                 .data('z-index', z + 9999)
                 .data('label', hintLabels[i])


### PR DESCRIPTION
jQuery's `offset` method uses `getBoundingClientRect`
(https://github.com/jquery/jquery/blob/3.2.1/src/offset.js#L99)
which sometimes leads to hints being placed outside the element if it
contains multiple rectangles, such as links that wrap around. Since
hints are always placed at the top, it makes sense to use the topmost
rectangle instead so hints are placed next to element there.

It's most noticeable when `settings.hintAlign` is set to `'left'`, for example (the "ph" hint is for "inline element" at the end):

![before](https://user-images.githubusercontent.com/2069450/34903875-5be1543e-f7ef-11e7-9b05-ccbb2a0dab1a.png)

Using the topmost rectangle instead:

![after](https://user-images.githubusercontent.com/2069450/34903877-64ec2c02-f7ef-11e7-85b8-16a143c23c93.png)

This also fixes `settings.hintAlign = 'right';` placing hints in the
center instead of on the right.