### PR TITLE
Fix opening about: URLs and change Firefox new tab to about:blank

### DIFF
--- a/background.js
+++ b/background.js
@@ -877,7 +877,7 @@ var ChromeService = (function() {
     };
     function normalizeURL(url) {
         if (!/^view-source:|^javascript:/.test(url) && /^(?:https?:\/\/)?(?:[^@\/\n]+@)?(?:www\.)?([^:\/\n]+)/im.test(url)) {
-            if (/^[\w-]+?:\/\//i.test(url)) {
+            if (/^[\w-]+?:/i.test(url)) {
                 url = url;
             } else {
                 url = "http://" + url;

--- a/pages/default.js
+++ b/pages/default.js
@@ -483,8 +483,8 @@ mapkey('ow', '#8Open Search with alias w', function() {
     Front.openOmnibar({type: "SearchEngine", extra: "w"});
 });
 if (window.navigator.userAgent.indexOf("Firefox") > 0) {
-    mapkey('on', '#3Open Chrome newtab', function() {
-        tabOpenLink("/pages/start.html");
+    mapkey('on', '#3Open Firefox newtab', function() {
+        tabOpenLink("about:blank");
     });
 } else {
     mapkey('on', '#3Open Chrome newtab', function() {


### PR DESCRIPTION
Since Firefox `about:` URLs lack two forward slashes, `normalizeURL`
prepends `http://` when trying to open them, resulting in invalid URLs
and errors. This just modifies the regular expression check to not
require slashes so `about:` URLs won't be modified.

This also changes the Firefox new tab to `about:blank` to match
the behavior in Chrome. `about:blank` is used instead of `about:newtab`
because the former allows some commands to be used (e.g. tab
manipulation like switching, closing, and moving) while the latter
doesn't allow any.