### PR TITLE
Use 'link[rel=prev/next]' tag for page navigation if available

### DIFF
--- a/content_scripts/content_scripts.js
+++ b/content_scripts/content_scripts.js
@@ -209,6 +209,10 @@ function walkPageUrl(step) {
 }
 
 function previousPage() {
+    var linkPrev = $('link[rel=prev]');
+    if (linkPrev.length >= 1) {
+        window.location.href = linkPrev.attr('href');
+    }
     var prevLinks = $('a:visible, button:visible, *:visible:css(cursor=pointer)').regex(runtime.conf.prevLinkRegex);
     prevLinks = $(filterOverlapElements(prevLinks.toArray()));
     if (prevLinks.length) {
@@ -220,6 +224,10 @@ function previousPage() {
 }
 
 function nextPage() {
+    var linkNext = $('link[rel=next]');
+    if (linkNext.length >= 1) {
+        window.location.href = linkNext.attr('href');
+    }
     var nextLinks = $('a:visible, button:visible, *:visible:css(cursor=pointer)').regex(runtime.conf.nextLinkRegex);
     nextLinks = $(filterOverlapElements(nextLinks.toArray()));
     if (nextLinks.length) {


### PR DESCRIPTION
'link[rel=prev/next]' html tags are used to indicate prev/next
locations. Use the information if present when navigating prev or
next page by ']]' or '[[' command, and use regex search if not available.