### PR TITLE
Fix custom hint and omnibar styling not working

### DIFF
--- a/content_scripts/hints.js
+++ b/content_scripts/hints.js
@@ -257,7 +257,7 @@ var Hints = (function() {
         _initHolder('click');
         var hintLabels = self.genLabels(elements.length);
         var bof = self.coordinate();
-        var style = createElement(`<style>#sk_hints>div${_styleForClick}</style>`);
+        var style = createElement(`<style>#sk_hints>div{${_styleForClick}}</style>`);
         holder.prepend(style);
         elements.forEach(function(elm, i) {
             var pos = elm.getClientRects()[0],
@@ -443,7 +443,7 @@ var Hints = (function() {
                 holder.append(e);
             });
 
-            var style = createElement(`<style>#sk_hints[mode='text']>div${_styleForText}</style>`);
+            var style = createElement(`<style>#sk_hints[mode='text']>div{${_styleForText}}</style>`);
             holder.prepend(style);
             document.documentElement.prepend(holder);
         }

--- a/pages/front.js
+++ b/pages/front.js
@@ -298,7 +298,7 @@ var Front = (function() {
     _actions['openOmnibar'] = function(message) {
         showPopup(self.omnibar, message);
         var style = message.style || "";
-        self.omnibar.querySelector('style').innerHTML = `#sk_omnibar ${style}`;
+        self.omnibar.querySelector('style').innerHTML = `#sk_omnibar {${style}}`;
     };
     self.openOmnibar = _actions['openOmnibar'];
     _actions['openFinder'] = function() {


### PR DESCRIPTION
In 45dd0c3 the strings to create the CSS were changed to use template
literals, but the curly braces weren't preserved/became part of the
`${}` placeholders so the CSS was invalid.

Congrats on removing jQuery also!