### PR TITLE
Fix MRU tab sort in Firefox

### DIFF
--- a/background.js
+++ b/background.js
@@ -641,8 +641,24 @@ var ChromeService = (function() {
                 return b.id !== tab.id;
             });
             if (conf.tabsMRUOrder) {
-                tabs.sort(function(a, b) {
-                    return tabActivated[b.id] - tabActivated[a.id];
+                tabs.sort(function(x, y) {
+                    // Shift tabs without "last access" data to the end
+                    var a = tabActivated[x.id];
+                    var b = tabActivated[y.id];
+
+                    if (!isFinite(a) && !isFinite(b)) {
+                        return 0;
+                    }
+
+                    if (!isFinite(a)) {
+                        return 1;
+                    }
+
+                    if (!isFinite(b)) {
+                        return -1;
+                    }
+
+                    return b - a;
                 });
             }
             _response(message, sendResponse, {


### PR DESCRIPTION
MRU tab sort didn't work for me in Firefox because not all tabs had the data in tabActivated object. This resulted in some comparisons being NaN (e.g. `10 - undefined = NaN`). In firefox this resulted in no-op sort. This PR includes checks to shift tabs without this data to the end.

This results in having a proper sort for tabs with data and tabs without data being at the end, which seems like the most reasonable behavior.