### PR TITLE
Edit filter logic to not filter out certain elements for hints

### DIFF
--- a/content_scripts/utils.js
+++ b/content_scripts/utils.js
@@ -189,14 +189,14 @@ function filterAncestors(elements) {
 function filterOverlapElements(elements) {
     // filter out tiny elements
     elements = elements.filter(function(e) {
-        var be = e.getBoundingClientRect();
+        var be = e.getClientRects()[0];
         if (e.disabled || e.readOnly || be.width <= 4) {
             return false;
         } else if (e.matches("input, textarea, select, form") || e.contentEditable === "true") {
             return true;
         } else {
             var el = document.elementFromPoint(be.left + be.width / 2, be.top + 3);
-            return !el || el.shadowRoot && el.childElementCount === 0 || el.contains(e);
+            return !el || el.shadowRoot && el.childElementCount === 0 || el.contains(e) || e.contains(el);
         }
     });
 


### PR DESCRIPTION
In `filterOverlapElements` in content_scripts/utils.js:

- Use the topmost rectangle instead of `getBoundingClientRect` to
account for elements that wrap around
- Additionally check if `el` is inside the element to account for
elements that contain other elements (like bold, span, etc.)

For example, with this page:

    <html>
      <head></head>
      <body>
        <a href="#link1">Link1</a>,
        <a href="#link2">Link2</a>,
        <a href="#bold"><b>Bold link</b></a>,
        <a href="#wrapping">Wrapping<br>link</a>
      </body>
    </html>

And this custom mapping:

    mapkey('e', '#1Display a link URL', function() {
      Hints.create('a', function(element) {
        alert(element.href);
      });
    });

Hints aren't generated for the last two links currently.