### PR TITLE
Adapt Omnibar.listResults to accept raw HTML

### DIFF
--- a/pages/omnibar.js
+++ b/pages/omnibar.js
@@ -422,6 +422,14 @@ var Omnibar = (function() {
         return li;
     };
 
+    self.createItemFromRawHtml = function({ html, props }) {
+        const li = createElement(html);
+        if (typeof props === "object") {
+            Object.assign(li, props);
+        }
+        return li;
+    };
+
     self.detectAndInsertURLItem = function(str, toList) {
         var urlPat = /^(?:https?:\/\/)?(?:[^@\/\n]+@)?(?:www\.)?([^:\/\n\s]+)\.([^:\/\n\s]+)/i,
             urlPat1 = /^https?:\/\/(?:[^@\/\n]+@)?([^:\/\n\s]+)/i;
@@ -481,11 +489,7 @@ var Omnibar = (function() {
         self.listResults(_page, function(b) {
             var li;
             if (b.hasOwnProperty('html')) {
-                li = createElement(b.html);
-                if (b.hasOwnProperty('props') && typeof b.props === "object") {
-                    Object.assign(li, b.props);
-                }
-                return li;
+                li = self.createItemFromRawHtml(b);
             } else if (b.hasOwnProperty('url')) {
                 li = self.createURLItem(b, rxp);
             } else if (_showFolder) {
@@ -1159,11 +1163,7 @@ var SearchEngine = (function() {
                         var rxp = _regexFromString(val, true);
                         Omnibar.listResults(resp, function (w) {
                             if (w.hasOwnProperty('html')) {
-                                li = createElement(w.html);
-                                if (w.hasOwnProperty('props') && typeof w.props === "object") {
-                                    Object.assign(li, w.props);
-                                }
-                                return li;
+                                return Omnibar.createItemFromRawHtml(w);
                             } else if (w.hasOwnProperty('url')) {
                                 return Omnibar.createURLItem(w, rxp);
                             } else {

--- a/pages/omnibar.js
+++ b/pages/omnibar.js
@@ -480,7 +480,13 @@ var Omnibar = (function() {
         }
         self.listResults(_page, function(b) {
             var li;
-            if (b.hasOwnProperty('url')) {
+            if (b.hasOwnProperty('html')) {
+                li = createElement(b.html);
+                if (b.hasOwnProperty('props') && typeof b.props === "object") {
+                    Object.assign(li, b.props);
+                }
+                return li;
+            } else if (b.hasOwnProperty('url')) {
                 li = self.createURLItem(b, rxp);
             } else if (_showFolder) {
                 li = createElement(`<li><div class="title">▷ ${self.highlight(rxp, b.title)}</div></li>`);
@@ -1152,7 +1158,13 @@ var SearchEngine = (function() {
                         Omnibar.detectAndInsertURLItem(Omnibar.input.value, resp);
                         var rxp = _regexFromString(val, true);
                         Omnibar.listResults(resp, function (w) {
-                            if (w.hasOwnProperty('url')) {
+                            if (w.hasOwnProperty('html')) {
+                                li = createElement(w.html);
+                                if (w.hasOwnProperty('props') && typeof w.props === "object") {
+                                    Object.assign(li, w.props);
+                                }
+                                return li;
+                            } else if (w.hasOwnProperty('url')) {
                                 return Omnibar.createURLItem(w, rxp);
                             } else {
                                 var li = createElement(`<li>⌕ ${w}</li>`);


### PR DESCRIPTION
Prior changes to SurfingKeys made it difficult or impossible for users
to return results as raw HTML items in custom Search Engine completion
functions.

This change allows for returning an object from the `addSearchAlias()`
`listSuggestion` callback of the following format:

```js
{
  html: "<li><b>FooBar</b></li>",  // 'html' is the raw HTML for the item, including a <li> container
  props: {                         // 'props' is an object containing any properties to be attached to the DOM element
    url: "https://example.com/"
  }
}
```

This change makes it possible for me to finally fix https://github.com/b0o/surfingkeys-conf/issues/2

You can see numerous example usages of this functionality in my configuration: https://github.com/b0o/surfingkeys-conf/blob/master/completions.js 

If necessary, I can update the documentation in the README - just let me know.