### PR TITLE
feat(hints): hint creation via array of elements

### DIFF
--- a/content_scripts/hints.js
+++ b/content_scripts/hints.js
@@ -331,6 +331,28 @@ var Hints = (function() {
         document.documentElement.prepend(holder);
     }
 
+    function createHintsForElements(elements, attrs) {
+        attrs = Object.assign({
+            active: true,
+            tabbed: false,
+            mouseEvents: ['mouseover', 'mousedown', 'mouseup', 'click'],
+            multipleHits: false,
+            filterInvisible: true
+        }, attrs || {});
+        for (var attr in attrs) {
+            behaviours[attr] = attrs[attr];
+        }
+        self.statusLine = (attrs && attrs.statusLine) || "Hints to click";
+
+        if (attrs.filterInvisible) {
+            elements = filterInvisibleElements(elements);
+        }
+        if (elements.length > 0) {
+            placeHints(elements);
+        }
+        return elements.length;
+    }
+
     function createHintsForClick(cssSelector, attrs) {
         self.statusLine = "Hints to click";
 
@@ -467,7 +489,12 @@ var Hints = (function() {
     }
 
     function createHints(cssSelector, attrs) {
-        return (cssSelector.constructor.name === "RegExp") ? createHintsForTextNode(cssSelector, attrs) : createHintsForClick(cssSelector, attrs);
+        if (cssSelector.constructor.name === "RegExp") {
+            return createHintsForTextNode(cssSelector, attrs);
+        } else if (Array.isArray(cssSelector)) {
+            return createHintsForElements(cssSelector, attrs);
+        }
+        return createHintsForClick(cssSelector, attrs);
     }
 
     self.createInputLayer = function() {


### PR DESCRIPTION
- create function `createHintsForElements` which takes an array of DOM
  elements and creates a hint for each one, optionally filtering out
  invisible elements by specifying `attrs.filterInvisible` (default true)

- modify `createHints` function to additionally check for the `cssSelector`
  argument to be an Array, and if so choosing to use the
  `createHintsForElements` function.

Prior to this change, it was impossible to create hints for sets of elements which cannot be specified through a simple CSS selector, which is not always sufficient. 

See several example usages here: https://github.com/b0o/surfingkeys-conf/blob/3f4a3c1e4df415c222597450dd20d6230d8aac7d/actions.js#L110-L166