### PR TITLE
tweak: attempt to treat OmniBar input as URL

### DIFF
--- a/pages/omnibar.js
+++ b/pages/omnibar.js
@@ -558,7 +558,11 @@ var Omnibar = (function() {
         } else {
             url = self.input.value;
             if (url.indexOf(':') === -1) {
-                url = SearchEngine.aliases[runtime.conf.defaultSearchEngine].url + url;
+                try {
+                    url = new URL(`https://${url}`).href;
+                } catch(e) {
+                    url = SearchEngine.aliases[runtime.conf.defaultSearchEngine].url + url;
+                }
             }
         }
         if (/^javascript:/.test(url)) {


### PR DESCRIPTION
If the user enters a string lacking a URI scheme, try to construct a URL by prepending 'https://', falling back to a query URL for the default search engine.