### PR TITLE
Gulp watch dev support

### DIFF
--- a/content_scripts/debug_utils.js
+++ b/content_scripts/debug_utils.js
@@ -1,3 +1,4 @@
+var isDev = true;
 /*
 *
 * breakOn("aa.scrollTop", 1)            break when aa.scrollTop is changed

--- a/content_scripts/hints.js
+++ b/content_scripts/hints.js
@@ -293,6 +293,7 @@ var Hints = (function() {
                 left = window.pageXOffset + window.innerWidth - 32;
             }
             var link = createElement(`<div>${hintLabels[i]}</div>`);
+            if(isDev) elm.dataset.hint_lable = hintLabels[i];
             link.style.top = Math.max(pos.top + window.pageYOffset - bof.top, 0) + "px";
             link.style.left = left + "px";
             link.style.zIndex = z + 9999;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -277,4 +277,4 @@ gulp.task('watch', gulp.series(['build', function watch() {
     ], gulp.series('copy-non-js-files'));
 }]));
 
-gulp.task('watch_firfox', gulp.series(['set_target_firefox', 'watch']));
+gulp.task('watch_firefox', gulp.series(['set_target_firefox', 'watch']));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -134,6 +134,7 @@ gulp.task('build_common_content_min_without_lib', function() {
     } else {
         common_content.push("content_scripts/chrome_fg.js");
     }
+    if (options.env === 'development') common_content.unshift('content_scripts/debug_utils.js');
     return gulp.src(common_content)
         .pipe(gulpif(options.env === 'development', sourcemaps.init()))
         .pipe(gp_concat('common_content.min.js'))
@@ -238,7 +239,8 @@ gulp.task('watch', gulp.series(['build', function watch() {
         "content_scripts/clipboard.js",
         "content_scripts/firefox_fg.js",
         "content_scripts/chrome_fg.js",
-        "libs/shadydom.min.js"
+        "libs/shadydom.min.js",
+        "content_scripts/debug_utils.js"
     ], gulp.series('build_common_content_min'));
 
     gulp.watch([

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -224,3 +224,57 @@ gulp.task('set_target_firefox', function (cb) {
     cb();
 });
 gulp.task('firefox', gulp.series(['set_target_firefox', 'build']));
+
+gulp.task('watch', gulp.series(['build', function watch() {
+    gulp.watch([
+        "libs/trie.js",
+        "content_scripts/keyboardUtils.js",
+        "content_scripts/utils.js",
+        "content_scripts/runtime.js",
+        "content_scripts/normal.js",
+        "content_scripts/insert.js",
+        "content_scripts/visual.js",
+        "content_scripts/hints.js",
+        "content_scripts/clipboard.js",
+        "content_scripts/firefox_fg.js",
+        "content_scripts/chrome_fg.js",
+        "libs/shadydom.min.js"
+    ], gulp.series('build_common_content_min'));
+
+    gulp.watch([
+        'background.js',
+        "firefox_pac.js",
+        "firefox_bg.js",
+        "chrome_bg.js"
+    ], gulp.series('build_background'));
+
+    gulp.watch(['manifest.json'], gulp.series('build_manifest'));
+
+    gulp.watch(['pages/*.html'], gulp.series('copy-html-files'));
+
+    gulp.watch([
+        'content_scripts/front.js',
+        'content_scripts/content_scripts.js',
+        'content_scripts/top.js',
+        'pages/*.js'
+    ], gulp.series('copy-es-files'));
+
+    gulp.watch([
+        'libs/ace/*.js',
+        "pages/pdf/*.js",
+        "libs/webfontloader.js",
+        'pages/default.js'
+    ], gulp.series('copy-pretty-default-js'));
+
+    gulp.watch([
+        'icons/**',
+        'content_scripts/**',
+        '!content_scripts/**/*.js',
+        'pages/**',
+        'libs/marked.min.js',
+        '!pages/**/*.html',
+        '!pages/**/*.js'
+    ], gulp.series('copy-non-js-files'));
+}]));
+
+gulp.task('watch_firfox', gulp.series(['set_target_firefox', 'watch']));

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "build": "gulp",
     "dev": "gulp --env development",
     "watch": "gulp watch --env development --nominify",
-    "watch_ff": "gulp watch_firfox --env development --nominify",
+    "watch_ff": "gulp watch_firefox --env development --nominify",
     "docs:watch": "documentation serve pages/*.js --watch"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "gulp",
     "dev": "gulp --env development",
+    "watch": "gulp watch --env development --nominify",
+    "watch_ff": "gulp watch_firfox --env development --nominify",
     "docs:watch": "documentation serve pages/*.js --watch"
   },
   "repository": {


### PR DESCRIPTION
- add 2 npm command to support gulp watch: building while code changes.
- add gloabal variable to identify the watching development mode
- add an example to using the gloabal variable: add hint lable to element when developing
- all developing or debuging support code could be added to the debug_utils.js file