### PR TITLE
Fix scrolling with smooth scrolling disabled with site overrides

### DIFF
--- a/content_scripts/normal.js
+++ b/content_scripts/normal.js
@@ -510,8 +510,11 @@ function createNormal() {
                 elm.smoothScrollBy(x, y, d);
             } else {
                 document.dispatchEvent(new CustomEvent('surfingkeys:scrollStarted'));
-                elm.scrollLeft = elm.scrollLeft + x;
-                elm.scrollTop = elm.scrollTop + y;
+                elm.scrollBy({
+                    'behavior': 'instant',
+                    'left': x,
+                    'top': y,
+                });
                 document.dispatchEvent(new CustomEvent('surfingkeys:scrollDone'));
             }
         };


### PR DESCRIPTION
When sites set 'scroll-behavior: smooth', previously j/k would trigger
smooth scrolling, even when smooth scrolling was disabled.

Example site:
https://www.travis-ci.org/libkeepass/pykeepass/branches