### PR TITLE
Disable autoFocus blurring when in insert or passthrough mode

### DIFF
--- a/content_scripts/insert.js
+++ b/content_scripts/insert.js
@@ -371,6 +371,8 @@ function createInsert() {
         var realTarget = getRealEdit(event);
         if (!isEditable(realTarget)) {
             self.exit();
+        } else {
+            event.sk_suppressed = true;
         }
     });
 

--- a/content_scripts/normal.js
+++ b/content_scripts/normal.js
@@ -331,6 +331,9 @@ function createPassThrough() {
     }).addEventListener('mousedown', function(event) {
         event.sk_suppressed = true;
     });
+    self.addEventListener('focus', function(event) {
+        event.sk_suppressed = true;
+    });
 
     self.onEnter = function() {
         if (_timeout > 0) {


### PR DESCRIPTION
enableAutoFocus prevents the page from grabbing focus by blurring any
focus events. However, when we are in insert/passthrough mode, we
ignore intentional blurs by the user and (on some sites) blur the
active element while typing.

This patch changes this behavior so this auto-blurring will not take
place in insert or passthrough mode, as those modes are meant for
user input and/or unimpeded interaction with the page.

The biggest problem site in this case is discord, which sends focus 
events to the focusable element all the time. Surfingkeys used to 
blur the page on these (with enableAutoFocus set to false), but this patch 
resolves that issue.