### PR TITLE
Fix tabHistory not being updated for new tabs

### DIFF
--- a/background.js
+++ b/background.js
@@ -362,7 +362,7 @@ var ChromeService = (function() {
         _updateTabIndices();
     });
     chrome.tabs.onActivated.addListener(function(activeInfo) {
-        if (tabURLs.hasOwnProperty(activeInfo.tabId) && !historyTabAction && activeInfo.tabId != tabHistory[tabHistory.length - 1]) {
+        if (!historyTabAction && activeInfo.tabId != tabHistory[tabHistory.length - 1]) {
             if (tabHistory.length > 10) {
                 tabHistory.shift();
             }


### PR DESCRIPTION
As far as I can tell, this check was doing nothing but preventing newly loaded tabs from being added to history (as they hadn't finished loading yet, they were not in the object). Let me know if that's not the case.

Previously, when a new tab was created, the "last/next tab stack" command would not go the last/next tab, but would instead go to the n-2 tab (as it thought the last tab was the current tab). In addition, the "go to last used tab" command seemed to completely break. These two functionalities seem to work with this patch.