### PR TITLE
Added hintExplicit option to disable automatic hint selection

### DIFF
--- a/content_scripts/hints.js
+++ b/content_scripts/hints.js
@@ -210,7 +210,7 @@ function createHints() {
     function resetHints(evt) {
         var start = new Date().getTime();
         var found = createHints(_cssSelector, _lastCreateAttrs);
-        if (found > 1) {
+        if (found > 0) {
             self.statusLine += " - " + (new Date().getTime() - start) + "ms / " + found;
             Mode.showStatus();
         }
@@ -548,7 +548,7 @@ function createHints() {
 
         var start = new Date().getTime();
         var found = createHints(cssSelector, attrs);
-        if (found > 1) {
+        if (found > (runtime.conf.hintExplicit ? 0 : 1)) {
             self.statusLine += " - " + (new Date().getTime() - start) + "ms / " + found;
             self.enter();
         } else {

--- a/content_scripts/runtime.js
+++ b/content_scripts/runtime.js
@@ -18,6 +18,7 @@ var runtime = (function() {
             focusFirstCandidate: false,
             focusOnSaved: true,
             hintAlign: "center",
+            hintExplicit: false,
             historyMUOrder: true,
             language: undefined,
             lastQuery: "",


### PR DESCRIPTION
Addresses #1083  by introducing `settings.hintExplicit` option. Setting this to `true` will prevent the hints module from taking the shortcut where it immediately jumps to the only hint available.