### PR TITLE
Added setting to open hints in background when holding shift

### DIFF
--- a/README.md
+++ b/README.md
@@ -659,6 +659,8 @@ For example,
 | settings.nextLinkRegex | /((>>&#124;next)+)/i | A regex to match links that indicate next page. |
 | settings.prevLinkRegex | /((<<&#124;prev(ious)?)+)/i| A regex to match links that indicate previous page. |
 | settings.hintAlign | "center" | Alignment of hints on their target elements. ["left", "center", "right"] |
+| settings.hintExplicit | false | Whether to wait for explicit input when there is only a single hint available |
+| settings.hintShiftNonActive | false | Whether new tab is active after entering hint while holding shift |
 | settings.defaultSearchEngine | "g" | The default search engine used in Omnibar. |
 | settings.blacklistPattern | undefined | A regex to match the sites that will have Surfingkeys disabled. |
 | settings.focusAfterClosed | "right" | Which tab will be focused after the current tab is closed. ["left", "right", "last"] |

--- a/content_scripts/hints.js
+++ b/content_scripts/hints.js
@@ -585,7 +585,10 @@ function createHints() {
                 active = false;
             }
 
-            if (shiftKey && window.navigator.userAgent.indexOf("Firefox") !== -1) {
+            if (shiftKey && runtime.conf.hintShiftNonActive) {
+                tabbed = true;
+                active = false;
+            } else if (shiftKey && window.navigator.userAgent.indexOf("Firefox") !== -1) {
                 // mouseButton does not work for firefox in mouse event.
                 tabbed = true;
                 active = true;

--- a/content_scripts/runtime.js
+++ b/content_scripts/runtime.js
@@ -18,6 +18,7 @@ var runtime = (function() {
             focusFirstCandidate: false,
             focusOnSaved: true,
             hintAlign: "center",
+            hintShiftNonActive: false,
             historyMUOrder: true,
             language: undefined,
             lastQuery: "",

--- a/pages/default.js
+++ b/pages/default.js
@@ -130,8 +130,8 @@ mapkey('?', '#0Show usage', function() {
     Front.showUsage();
 });
 map('u', 'e');
-mapkey('af', '#1Open a link in new tab', function() {
-    Hints.create("", Hints.dispatchMouseClick, {tabbed: true});
+mapkey('af', '#1Open a link in active new tab', function() {
+    Hints.create("", Hints.dispatchMouseClick, {tabbed: true, active: true});
 });
 mapkey('gf', '#1Open a link in non-active new tab', function() {
     Hints.create("", Hints.dispatchMouseClick, {tabbed: true, active: false});

--- a/pages/l10n.json
+++ b/pages/l10n.json
@@ -122,7 +122,7 @@
         "Open a URL": "打开网页",
         "Open a URL in current tab": "在当前标签页打开网页",
         "Open a bookmark": "打开一个收藏",
-        "Open a link in new tab": "在新标签页打开链接",
+        "Open a link in active new tab": "在新标签页打开链接",
         "Open a link in non-active new tab": "在新标签页后台打开链接",
         "Open a link, press SHIFT to flip hints if they are overlapped.": "打开链接，如果拨号键有重叠按SHIFT",
         "Open commands": "打开命令",


### PR DESCRIPTION
Addresses #417 by adding a setting `hintShiftNonActive` that, when `true`, opens hints in non-active tabs.

Tested on Firefox and Chrome.