### PR TITLE
Make Hints.create() use cssSelector when tabbed

### DIFF
--- a/content_scripts/hints.js
+++ b/content_scripts/hints.js
@@ -354,24 +354,23 @@ function createHints() {
             behaviours[attr] = attrs[attr];
         }
         var elements;
-        if (behaviours.tabbed) {
-            elements = Array.from(getElements('a[href]:not([href^=javascript])'));
-            elements = filterInvisibleElements(elements);
+        if (behaviours.tabbed && cssSelector === "") {
+            cssSelector = 'a[href]:not([href^=javascript])' ;
+        }
+
+        if (cssSelector === "") {
+            elements = getVisibleElements(function(e, v) {
+                if (isElementClickable(e)) {
+                    v.push(e);
+                }
+            });
+            elements = filterOverlapElements(elements);
+        } else if (Array.isArray(cssSelector)) {
+            elements = filterInvisibleElements(cssSelector);
         } else {
-            if (cssSelector === "") {
-                elements = getVisibleElements(function(e, v) {
-                    if (isElementClickable(e)) {
-                        v.push(e);
-                    }
-                });
-                elements = filterOverlapElements(elements);
-            } else if (Array.isArray(cssSelector)) {
-                elements = filterInvisibleElements(cssSelector);
-            } else {
-                elements = Array.from(document.documentElement.querySelectorAll(cssSelector));
-                elements = filterInvisibleElements(elements);
-                elements = filterOverlapElements(elements);
-            }
+            elements = Array.from(document.documentElement.querySelectorAll(cssSelector));
+            elements = filterInvisibleElements(elements);
+            elements = filterOverlapElements(elements);
         }
 
         if (elements.length > 0) {


### PR DESCRIPTION
`Hints.create()` currently ignores `cssSelector` parameter when called with `attrs` containing `tabbed: true`. This patch tries to retain the old behavior for when `cssSelector` is blank, but to use `cssSelector` when it's specified by caller. So now we can do e.g. `  Hints.create("a.title", Hints.dispatchMouseClick, {tabbed: true});` on reddit and it works as expected.