### PR TITLE
Fix EOL in insert mode with contenteditable

### DIFF
--- a/content_scripts/insert.js
+++ b/content_scripts/insert.js
@@ -20,7 +20,7 @@ function createInsert() {
                 if (node.nodeType === Node.TEXT_NODE) {
                     document.getSelection().setPosition(node, node.data.length);
                 } else {
-                    document.getSelection().setPosition(node, 0);
+                    document.getSelection().setPosition(node, node.childNodes.length);
                 }
                 // blink cursor to bring cursor into view
                 Visual.showCursor();


### PR DESCRIPTION
In contenteditable elements where the first child is not a text-node, the end-of-line function would instead go to the start of the line (as it was indexed by 0). This diff changes that so the end-of-line function goes to the end of the children (which, in the cases I'm observing), goes to the end of the entire document.

This isn't the same as the end of line, but it's much better than start of document for me at least. 

The alternative is to recurse inside the contentEditable looking for a text node, instead of just going one level deeper. 

Let me know if you have any questions. I based the change off of this blog post's documentation of selection offsets:

https://javascript.info/selection-range

(this fixes "end of line" in some js chat applications I use)