### PR TITLE
Fix enableAutoFocus blurring when entering insert mode dynamically

### DIFF
--- a/content_scripts/normal.js
+++ b/content_scripts/normal.js
@@ -370,10 +370,10 @@ function createNormal() {
                         Mode.handleMapKey.call(self, event);
                     }
                 } else {
-                    Normal.passFocus(true);
                     event.sk_stopPropagation = (runtime.conf.editableBodyCare
                         && realTarget === document.body && event.key === "i");
                     if (event.sk_stopPropagation) {
+                        Normal.passFocus(true);
                         realTarget.focus();
                     }
 


### PR DESCRIPTION
Insert mode can be entered at the end of this function (line 395), if the cursor
somehow is focused via previous actions, but we are in normal mode. In
this case, we enter insert mode with passFocus=true, which makes the
first focus upon leaving insert mode pass through, even if
enableAutoFocus is set to false.

This fixes that issue by running passFocus = true only when we
actually focus an element.

I am assuming Mode.handleMapKey.call(self, event) does NOT need
passFocus = true, as it is used above without passFocus being set.

Alternatively I can set passFocus=False before the call on 395, but this 
seems cleaner to me. Let me know what you think.