### PR TITLE
Fix search marks being offset on some pages

### DIFF
--- a/content_scripts/visual.js
+++ b/content_scripts/visual.js
@@ -516,13 +516,18 @@ function createVisual() {
 
     var holder = document.createElement("div");
     function createMatchMark(node1, offset1, node2, offset2) {
+        // document.body can be offset via a margin, and while absolute
+        // position is relative to body, getBoundingClientRect is relative to
+        // the viewport. Calculate the position at zero scroll to compensate.
+        const bodyOffsetX = document.body.getBoundingClientRect().left + document.scrollingElement.scrollLeft;
+        const bodyOffsetY = document.body.getBoundingClientRect().top + document.scrollingElement.scrollTop;
         var r = getTextRect(node1, offset1, node2, offset2);
         if (r.width > 0 && r.height > 0) {
             var mark = mark_template.cloneNode(false);
             mark.style.position = "absolute";
             mark.style.zIndex = 2147483298;
-            mark.style.left = document.scrollingElement.scrollLeft + r.left + 'px';
-            mark.style.top = document.scrollingElement.scrollTop + r.top + 'px';
+            mark.style.left = document.scrollingElement.scrollLeft + r.left - bodyOffsetX + 'px';
+            mark.style.top = document.scrollingElement.scrollTop + r.top - bodyOffsetY + 'px';
             mark.style.width = r.width + 'px';
             mark.style.height = r.height + 'px';
             holder.appendChild(mark);


### PR DESCRIPTION
On some pages, `document.body` is offset from the viewport. An example is here:
https://minecraft.gamepedia.com/Version_history

On this page, document.body is shifted down 30px, which leads to hints being 30px below where they should be. For `position: absolute`, x/y are relative to the parent and/or `document.body` (as far as I can tell), so we can fix this by subtracting the `document.body` top and left values. Since these values change with scroll (and I just want the offset), I added the scroll values as well. This feels a little hacky, but this is the best solution I came up with.

Let me know if you see a better solution to solve this problem!

Before:
![1588221685](https://user-images.githubusercontent.com/4349709/80672805-8cb01700-8a62-11ea-9dbf-e87c24b38b49.png)


After:
![1588221702](https://user-images.githubusercontent.com/4349709/80672812-8f127100-8a62-11ea-83f2-2d2fce8a245a.png)
