### PR TITLE
Fix DOMPurify mangling user CSS

### DIFF
--- a/pages/front.js
+++ b/pages/front.js
@@ -251,7 +251,9 @@ var Front = (function() {
             }
         }
         if ('theme' in message.userSettings) {
-            setSanitizedContent(document.getElementById("sk_theme"), message.userSettings.theme);
+            // userSettings.theme is CSS, not HTML. DOMPurify mangles css, and
+            // user settings is trusted, so set it as is.
+            document.getElementById("sk_theme").innerHTML = message.userSettings.theme;
         }
     };
     _actions['executeCommand'] = function (message) {


### PR DESCRIPTION
Currently, the dark theme setting as documented in options.html does not properly function as DOMPurify seems to mangle raw CSS given to it:


![1589319698](https://user-images.githubusercontent.com/4349709/81748451-bdc71900-945e-11ea-89ad-3bac6ed952d3.png)

Given that the user config is trusted anyway, and that this is CSS and not HTML, I decided to just set it as-is. If you know a way to santize CSS I'd be happy to use that instead.