### PR TITLE
Prevent browser window focus from exiting insert mode

### DIFF
--- a/content_scripts/insert.js
+++ b/content_scripts/insert.js
@@ -370,7 +370,9 @@ function createInsert() {
     });
     self.addEventListener('focus', function(event) {
         var realTarget = getRealEdit(event);
-        if (!isEditable(realTarget)) {
+        // We get a focus event with target = window when the browser window looses focus.
+        // Ignore this event.
+        if (event.target != window && !isEditable(realTarget)) {
             self.exit();
         } else {
             event.sk_suppressed = true;


### PR DESCRIPTION
When the browser window looses and gains focus, currently surfingkeys exits insert mode. This is because (for some reason) we get a focus event with `target = window` (even though no focus on the page itself changed). I'm not sure why this event is being fired (or much documentation on the behavior) other than this SO post:

https://stackoverflow.com/questions/3478654/is-there-a-browser-event-for-the-window-getting-focus

To solve this I just ignored focus events with `event.target = window` for the purposes of leaving insert mode. I'm not exactly sure where this handler is attached, but the simplest solution I can see is just ignoring focus events for the window object. 

If you understand this better and see a better solution, let me know. If you want me to put this behavior behind a config flag, let me know as well (not leaving insert mode when the chrome browser window loses/gains focus).