### PR TITLE
Fix search highlights by placing them in document.documentElement

### DIFF
--- a/content_scripts/visual.js
+++ b/content_scripts/visual.js
@@ -516,23 +516,18 @@ function createVisual() {
 
     var holder = document.createElement("div");
     function createMatchMark(node1, offset1, node2, offset2) {
-        // document.body can be offset via a margin, and while absolute
-        // position is relative to body, getBoundingClientRect is relative to
-        // the viewport. Calculate the position at zero scroll to compensate.
-        const bodyOffsetX = document.body.getBoundingClientRect().left + document.scrollingElement.scrollLeft;
-        const bodyOffsetY = document.body.getBoundingClientRect().top + document.scrollingElement.scrollTop;
         var r = getTextRect(node1, offset1, node2, offset2);
         if (r.width > 0 && r.height > 0) {
             var mark = mark_template.cloneNode(false);
             mark.style.position = "absolute";
             mark.style.zIndex = 2147483298;
-            mark.style.left = document.scrollingElement.scrollLeft + r.left - bodyOffsetX + 'px';
-            mark.style.top = document.scrollingElement.scrollTop + r.top - bodyOffsetY + 'px';
+            mark.style.left = document.scrollingElement.scrollLeft + r.left + 'px';
+            mark.style.top = document.scrollingElement.scrollTop + r.top + 'px';
             mark.style.width = r.width + 'px';
             mark.style.height = r.height + 'px';
             holder.appendChild(mark);
-            if (!document.body.contains(holder)) {
-                document.body.appendChild(holder);
+            if (!document.documentElement.contains(holder)) {
+                document.documentElement.prepend(holder);
             }
 
             matches.push([node1, offset1, mark]);


### PR DESCRIPTION
Unfortunately the change in #1220 wasn't perfect, as it seems like placing `position: relative` or `position: absolute` on `document.body` (or `document.documentElement`) changes the results from boundingClientRect. The previous diff fixed it in the 'absolute/relative' case but not in the other cases. I couldn't find much information on this behavior, other than this comment on this blog post:

https://johnresig.com/blog/getboundingclientrect-is-awesome/#comment-313375

![1589568929](https://user-images.githubusercontent.com/4349709/82086190-fe16d900-96a2-11ea-9eb3-fe6442b5aec6.png)

As this is getting rather complicated, I decided to revert the change mostly, and instead place the surfingkeys search hints in `document.documentElement` instead of `document.body` (in the hopes that less people will modify `docuement.documentElement`. However, this method will still not work if people do set `position: relative/absolute` on `document.documentElement`, so this might need more investigation. Is adding these hints to the top-level safe? If it isn't, I can try to work-around this by changing behavior in the relative/absolute case.

However, one downsides of this approach is that I needed to lower the z-index so that the cursor would appear over the hints. 

Here are the websites I tested so far:
MC Wiki: https://minecraft.gamepedia.com/Version_history
![1589568604](https://user-images.githubusercontent.com/4349709/82085726-47b2f400-96a2-11ea-8b08-4f2b9c401bf9.png)

YCombinator: https://news.ycombinator.com/
![1589568658](https://user-images.githubusercontent.com/4349709/82085784-5dc0b480-96a2-11ea-819b-037f5ca96320.png)

Stackoverflow (with nojs header): https://stackoverflow.com/questions/491052/minimum-and-maximum-value-of-z-index
![1589568705](https://user-images.githubusercontent.com/4349709/82085843-77fa9280-96a2-11ea-96c4-7ba7e1ca9d12.png)

Java API: https://docs.oracle.com/javase/8/docs/api/overview-summary.html
![1589568795](https://user-images.githubusercontent.com/4349709/82085992-aed0a880-96a2-11ea-8117-f8ef74313e42.png)
