### PR TITLE
Recompute scrollable elements automatically when invalidated

### DIFF
--- a/content_scripts/normal.js
+++ b/content_scripts/normal.js
@@ -657,8 +657,8 @@ function createNormal() {
                 var br = scrollNode.getBoundingClientRect();
                 if (br.width === 0 || br.height === 0 || !isElementPartiallyInViewport(scrollNode)
                     || !hasScroll(scrollNode, 'x', 16) && !hasScroll(scrollNode, 'y', 16)) {
-                    scrollNodes.splice(scrollIndex, 1);
-                    scrollIndex = 0;
+                    // Recompute scrollable elements, the webpage has changed.
+                    self.refreshScrollableElements();
                     scrollNode = scrollNodes[scrollIndex];
                 }
             }


### PR DESCRIPTION
Currently, when an element which is scrollable is deleted or becomes invalid in another way, the element is simply not considered for scrolling anymore, and the next element (from the prior search) is selected. This is fine for webpages which aren't too interactable, but for a webpage which regularly deletes and re-creates it's main scrolling element (some chat applications) this becomes tedious. There is a binding to force recomputing scrollable elements, but it would be a pain to repeatedly press this whenever the page changes. I also tried to add the refresh function to the bindings I use to change the scrolling layout, but they occured too early to make use of the new layout.

This diff changes this case to force a recompute of all scrolling elements when the current scrolling element is invalidated. For example, if a chat window pane is deleted and replaced with a new one, this recompute should automatically detect the change and keep scrolling as usual. The example site I tested with was discord, as most other chat programs don't replace the main window.

However, if the getScrollableElements function returns invalid elements to begin with, this could result in the array being recomputed every scroll. If you think this is an issue, I could add the 'isElementPartiallyInViewport' and bounding rect filters in the getScrollableElements function itself to avoid this case. 

If you prefer the old behavior, I can also add a config setting. Let me know what you think!