### PR TITLE
Expose ombibar input to search suggestion callback

### DIFF
--- a/content_scripts/front.js
+++ b/content_scripts/front.js
@@ -93,7 +93,7 @@ function createFront() {
     _actions["getSearchSuggestions"] = function (message) {
         var ret = null;
         if (_listSuggestions.hasOwnProperty(message.url)) {
-            ret = _listSuggestions[message.url](message.response);
+            ret = _listSuggestions[message.url](message.response, message.input);
         }
         return ret;
     };

--- a/pages/omnibar.js
+++ b/pages/omnibar.js
@@ -1147,7 +1147,8 @@ var SearchEngine = (function() {
                 Front.contentCommand({
                     action: 'getSearchSuggestions',
                     url: self.suggestionURL,
-                    response: resp
+                    response: resp,
+                    input: Omnibar.input.value
                 }, function(resp) {
                     resp = resp.data;
                     if (!Array.isArray(resp)) {


### PR DESCRIPTION
This simple PR exposes omnibar user's input to search suggestion callback.

There are scenario where you would want access to what user typed in the callback.
For example, I was creating a search suggestion for . In the webpage, it uses multiple api calls where:
1.
```
https://api-portal.dictionary.com/spellSuggestions/${WORD}
```
to provide **spell suggestion**, and
2. 
```
https://tuna.thesaurus.com/pageData/${WORD}
```
to provide the actual **thesaurus result**.

I want to make the ombibar preview the actual result (the No.2), but it losses the ability to provide spell suggestion (No.1) because the two api calls are distinct, meaning that if your **spell is correct**, api 1 would returns null (api 2 works as normal). If your spell is incorrect, api 1 would returns a list of suggested correctly-spelled words (api 2 would returns null).


I was trying to make api 2 URL as the suggestionURL, and fallback to api 1 if api 2 returns null (meaning your spell is incorrect and omnibar would provide suggestion of correctly spelled words).

However, there is currently no way to access what user had typed in the callback. This PR append the `Omnibar.input.value` to the callback, and should be backward-compatible to any previous script.