### PR TITLE
add child selector instruction to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -693,6 +693,8 @@ For example,
             font-size: 20pt;
         }
     }`;
+* Notice: CSS child selector > will be normalized, please use `SPACE` instead.
+  * example: `.sk_theme #sk_omnibarSearchResult ul li:nth-child(odd)`
 
 ## API Documentation
 


### PR DESCRIPTION
The `>` is normalized to `&gt;` in the theme. 
Almost gonna send a PR to fix the behavior until i see the #1229  and your [comment for the workaround](https://github.com/brookhong/Surfingkeys/pull/1229#issuecomment-627690980). 

IMHO, it would save a lot of time if i can find it in the main README.

@brookhong Thanks for the awesome extension again! Cannot live without it. 💯 