### PR TITLE
Fix no overwrite when internal error

### DIFF
--- a/background.js
+++ b/background.js
@@ -258,8 +258,7 @@ var ChromeService = (function() {
                     cb(set);
                 }, undefined, undefined, function (po) {
                     // failed to read snippets from localPath
-                    set.error = "Failed to read snippets from " + set.localPath;
-                    cb(set);
+                    console.error("Failed to read snippets from " + set.localPath);
                 });
             } else {
                 cb(set);

--- a/background.js
+++ b/background.js
@@ -8,7 +8,13 @@ function request(url, onReady, headers, data, onException) {
             xhr.setRequestHeader(h, headers[h]);
         }
         xhr.onload = function() {
-            acc(xhr.responseText);
+            if (xhr.readyState === xhr.DONE) {
+                if (xhr.status === 200) {
+                    acc(xhr.responseText);
+                } else {
+                    rej(xhr.status);
+                }
+            }
         };
         xhr.onerror = rej.bind(null, xhr);
         xhr.send(data);

--- a/background.js
+++ b/background.js
@@ -611,8 +611,10 @@ var ChromeService = (function() {
         });
     };
     self.loadSettingsFromUrl = function(message, sender, sendResponse) {
-        _loadSettingsFromUrl(message.url, function(status) {
-            _response(message, sendResponse, status);
+        _loadSettingsFromUrl(message.url, function(result) {
+            if (!(result && result.status === "Failed")) {
+                _response(message, sendResponse, status);
+            }
         });
     };
     function _filterByTitleOrUrl(tabs, query) {

--- a/pages/options.js
+++ b/pages/options.js
@@ -315,6 +315,9 @@ function saveSettings() {
         RUNTIME('loadSettingsFromUrl', {
             url: localPath
         }, function(res) {
+            if (res.status && res.status === "Failed") {
+                return;
+            }
             Front.showBanner(res.status + ' to load settings from ' + localPath, 300);
             renderKeyMappings(res);
             if (res.snippets && res.snippets.length) {


### PR DESCRIPTION
![screenshot-2020-06-29-18-12-49](https://user-images.githubusercontent.com/2913112/87286410-cce84700-c533-11ea-9246-81a19833d046.png)

I setting file on GitHub.

1. Surfingkeys don't detect internal error.
2. When network error, and Surfingkeys overwrite setting by default.

I fix that surfingkeys don't nothing when internal error.