### PR TITLE
toggleQuote: handle quote only at one end

### DIFF
--- a/content_scripts/utils.js
+++ b/content_scripts/utils.js
@@ -94,8 +94,8 @@ function getRealEdit(event) {
 
 function toggleQuote() {
     var elm = getRealEdit(), val = elm.value;
-    if (val[0] === '"') {
-        elm.value = val.substr(1, val.length - 2);
+    if (val.match( /^"|"$/)) {
+        elm.value = val.replace(/^"?(.*?)"?$/, '$1');
     } else {
         elm.value = '"' + val + '"';
     }

--- a/content_scripts/utils.js
+++ b/content_scripts/utils.js
@@ -94,7 +94,7 @@ function getRealEdit(event) {
 
 function toggleQuote() {
     var elm = getRealEdit(), val = elm.value;
-    if (val.match( /^"|"$/)) {
+    if (val.match(/^"|"$/)) {
         elm.value = val.replace(/^"?(.*?)"?$/, '$1');
     } else {
         elm.value = '"' + val + '"';


### PR DESCRIPTION
Current flow:
Using toggleQuote function mapped as below:
`imapkey("<Ctrl-'>", '#15Toggle quotes in an input element', toggleQuote);`

When the initial string has a quote on the end and if user wants to unquote, **toggleQuote** cant be used.

New flow:
**original string ends with a quote"**   --->  **original string ends with a quote**

