### PR TITLE
Omnibar: Copy currently focussed url

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -29,6 +29,7 @@ Key bindings in Omnibar:
 -   `Ctrl-`. to show results of next page
 -   `Ctrl-`, to show results of previous page
 -   `Ctrl-c` to copy all listed items
+-   `Ctrl-e` to copy currently focussed item url
 -   In omnibar opened with `t:`
 
 `Ctrl - d` to delete from bookmark or history

--- a/pages/omnibar.js
+++ b/pages/omnibar.js
@@ -59,6 +59,7 @@ function _filterByTitleOrUrl(urls, query) {
  *  * `Ctrl-`. to show results of next page
  *  * `Ctrl-`, to show results of previous page
  *  * `Ctrl-c` to copy all listed items
+ *  * `Ctrl-e` to copy currently focussed item url
  *  * In omnibar opened with `t:`
  *
  * `Ctrl - d` to delete from bookmark or history
@@ -185,6 +186,17 @@ var Omnibar = (function() {
             self.input.style.display = "none";
             Clipboard.write(JSON.stringify(_page, null, 4));
             self.input.style.display = "";
+        }
+    });
+
+    self.mappings.add(KeyboardUtils.encodeKeystroke("<Ctrl-e>"), {
+        annotation: "Copy currently focussed item url",
+        feature_group: 8,
+        code: function () {
+            var fi = Omnibar.resultsDiv.querySelector('li.focused');
+            if (fi && fi.uid) {
+                Clipboard.write(fi.url);
+            }
         }
     });
 


### PR DESCRIPTION
Copy url of the currently focussed item in omnibar using
`Ctrl-e` to copy currently focussed item url
Currently we can only copy everything as a json.