### PR TITLE
Set ui frame opacity to 0

### DIFF
--- a/content_scripts/uiframe.js
+++ b/content_scripts/uiframe.js
@@ -1,7 +1,7 @@
 function createUiHost() {
     var uiHost = document.createElement("div");
     uiHost.style.display = "block";
-    uiHost.style.opacity = 1;
+    uiHost.style.opacity = 0;
     var frontEndURL = chrome.runtime.getURL('pages/frontend.html');
     var ifr = document.createElement("iframe");
     ifr.setAttribute('allowtransparency', true);


### PR DESCRIPTION
This fixes #1363, which was where triggering the Surfingkeys UI (any
part of it) caused the whole page to go white