### PR TITLE
Get closest contiguous clickable element for hints to reduce duplicat…

### DIFF
--- a/content_scripts/hints.js
+++ b/content_scripts/hints.js
@@ -404,8 +404,9 @@ div.hint-scrollable {
         } else {
             if (cssSelector === "") {
                 elements = getVisibleElements(function(e, v) {
-                    if (isElementClickable(e)) {
-                        v.push(e);
+                    var closestClickable = getFurthestContiguousClickable(e);
+                    if (closestClickable) {
+                        v.push(closestClickable);
                     }
                 });
                 elements = filterOverlapElements(elements);

--- a/content_scripts/utils.js
+++ b/content_scripts/utils.js
@@ -60,6 +60,15 @@ function isElementClickable(e) {
         || e.closest("a, *[onclick], *[contenteditable=true], *.jfk-button, *.goog-flat-menu-button") !== null;
 }
 
+function getFurthestContiguousClickable(e) {
+    var clickable = isElementClickable(e);
+    var parent = e.parentElement;
+    if(clickable){
+        return getFurthestContiguousClickable(parent) || e;
+    }
+    return clickable;
+}
+
 function dispatchMouseEvent(element, events, shiftKey) {
     events.forEach(function(eventName) {
         var mouseButton = shiftKey ? 1 : 0;


### PR DESCRIPTION
…e hints

Addresses #1448 

SurfingKeys applies hints to any elements if they're clickable and visible. I modified SurfingKeys to find the furthest contiguous ancestor that is clickable. This significantly reduces duplicate hints, and should make it clearer what clickable region each hint actually refers to.

I experimented with deduplicating on the href, but that didn't seem to have much effect, and is excluded from this PR.

![GMail hints](https://user-images.githubusercontent.com/10100843/120043999-f5a5ed80-bfda-11eb-89fa-8dbdf16c7d93.png)
