### PR TITLE
Alias default url

### DIFF
--- a/content_scripts/content_scripts.js
+++ b/content_scripts/content_scripts.js
@@ -160,6 +160,10 @@ function removeSearchAlias(alias) {
     Front.removeSearchAlias(alias);
 }
 
+function addAliasDefaultUrl(alias, default_url) {
+    Front.addAliasDefaultUrl(alias, default_url);
+}
+
 function addSearchAliasX(alias, prompt, search_url, search_leader_key, suggestion_url, callback_to_parse_suggestion, only_this_site_key) {
     addSearchAlias(alias, prompt, search_url, suggestion_url, callback_to_parse_suggestion);
     function ssw() {

--- a/content_scripts/front.js
+++ b/content_scripts/front.js
@@ -58,6 +58,13 @@ function createFront() {
             alias: alias
         });
     };
+    self.addAliasDefaultUrl = function (alias, default_url) {
+        _uiUserSettings.push({
+            action: 'addAliasDefaultUrl',
+            alias: alias,
+            default_url: default_url
+        });
+    };
 
     var _actions = {};
 

--- a/pages/front.js
+++ b/pages/front.js
@@ -274,12 +274,21 @@ var Front = (function() {
         SearchEngine.aliases[message.alias] = {
             prompt: '' + message.prompt + separatorHtml,
             url: message.url,
-            suggestionURL: message.suggestionURL
+            suggestionURL: message.suggestionURL,
         };
     };
     _actions['removeSearchAlias'] = function (message) {
         delete SearchEngine.aliases[message.alias];
     };
+    _actions['addAliasDefaultUrl'] = function (message) {
+        if (! message.alias in SearchEngine.aliases) {
+            return;
+        }
+        else {
+            SearchEngine.aliases[message.alias].default_url = message.default_url;
+        }
+    };
+
     _actions['getUsage'] = function (message) {
         // send response in callback from buildUsage
         delete message.ack;

--- a/pages/front.js
+++ b/pages/front.js
@@ -274,7 +274,7 @@ var Front = (function() {
         SearchEngine.aliases[message.alias] = {
             prompt: '' + message.prompt + separatorHtml,
             url: message.url,
-            suggestionURL: message.suggestionURL,
+            suggestionURL: message.suggestionURL
         };
     };
     _actions['removeSearchAlias'] = function (message) {

--- a/pages/omnibar.js
+++ b/pages/omnibar.js
@@ -1203,6 +1203,7 @@ const SearchEngine = (function() {
         clearPendingRequest();
         self.prompt = undefined;
         self.url = undefined;
+        self.default_url = undefined;
         self.suggestionURL = undefined;
     };
     self.onTabKey = function() {
@@ -1216,7 +1217,12 @@ const SearchEngine = (function() {
         if (fi) {
             url = fi.url || constructSearchURL(self.url, (fi.query || encodeURIComponent(Omnibar.input.value)));
         } else {
-            url = constructSearchURL(self.url, encodeURIComponent(Omnibar.input.value));
+            if (!Omnibar.input.value.trim() && typeof self.default_url !== "undefined") {
+                url = self.default_url;
+            }
+            else{
+                url = constructSearchURL(self.url, encodeURIComponent(Omnibar.input.value));
+            }
         }
         RUNTIME("openLink", {
             tab: {


### PR DESCRIPTION
Hi, 
this PR addresses the need for a default url to replace the one
specified when creating an alias, when no input is given to the
omnibar other than the alias.
This feature, which i miss from vimiumc, is to set an url for
those site for which you want an alias, but also redirect to
another url (e.g. an homepage) when you don't provide a
result to search for.
I implemented that as an user setting, to avoid changes to
the already crowded signature of _addSearchAlias_ :
```
addAliasDefaultUrl(alias, default_url)
```
where _alias_ must be a defined alias.
Thanks for your consideration and for your work


https://user-images.githubusercontent.com/33786518/130562285-3612e47c-199b-45c0-9938-f5298223394f.mp4