### PR TITLE
Export filterAncestors for omnibar

### DIFF
--- a/src/content_scripts/common/utils.js
+++ b/src/content_scripts/common/utils.js
@@ -739,6 +739,7 @@ export {
     createElementWithContent,
     dispatchMouseEvent,
     dispatchSKEvent,
+    filterAncestors,
     filterInvisibleElements,
     filterOverlapElements,
     flashPressedLink,

--- a/src/content_scripts/common/visual.js
+++ b/src/content_scripts/common/visual.js
@@ -5,6 +5,7 @@ import KeyboardUtils from './keyboardUtils';
 import {
     actionWithSelectionPreserved,
     dispatchMouseEvent,
+    filterAncestors,
     flashPressedLink,
     getBrowserName,
     getTextNodes,


### PR DESCRIPTION
After #1587 I'm able to register inline query but translation is still not working. Pressing `Q` throws `ReferenceError: filterAncestors is not defined` and doesn't show any results. This PR exports and imports the function to fix omnibar translation