### PR TITLE
Change `iunmap` to `api.iunmap` in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ When user inputs a colon and 2(set by `settings.startToShowEmoji`) characters su
 
 If you want this feature disabled completely, use below settings:
 
-    iunmap(":");
+    api.iunmap(":");
 
 If you'd like emoji suggestions popup as soon as you input colon, use below:
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -163,7 +163,7 @@ Surfingkeys有三种模式：normal，visual和insert。
 
 如果你不喜欢这个功能，可以用以下设置禁用：
 
-    iunmap(":");
+    api.iunmap(":");
 
 如果你希望按下冒号后立刻出现表情下拉选项，可以用以下设置：
 


### PR DESCRIPTION
Seems like `iunmap` stopped to work in settings, the functional
alternative is `api.iunmap`, so this commit updates READMEs to use it
when explaining how to disable emoji completion.
