### PR TITLE
Enable file explorer when saving images

### DIFF
--- a/src/background/start.js
+++ b/src/background/start.js
@@ -1311,7 +1311,7 @@ function start(browser) {
         });
     };
     self.download = function(message, sender, sendResponse) {
-        chrome.downloads.download({ url: message.url })
+        chrome.downloads.download({ url: message.url, saveAs: message.saveAs });
     };
     self.executeScript = function(message, sender, sendResponse) {
         chrome.tabs.executeScript(sender.tab.id, {


### PR DESCRIPTION
I'd like to be able to select where I want to save images when using `;di`. After looking through [the chrome downloads docs](https://developer.chrome.com/docs/extensions/reference/downloads/#type-DownloadOptions), it looks like there is a field called `saveAs` for this. I wanted to add this to my personal settings, but it looks like a small change is required to send it to chrome.

With this change, I'm able to achieve it by adding 
```javascript
api.mapkey(";di", "#1Download Image", function() {
   api.Hints.create('img', function(element) {
       api.RUNTIME('download', {
           url: element.src,
           saveAs: true,
       })
   }) 
});
```
to my settings.

As a corollary to this, I wonder why it was chosen not to pass the entire message object, since that way users will be able to use the settings more flexibly.