### PR TITLE
API: Make search engine favicon configurable

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -320,6 +320,7 @@ Add a search engine alias into Omnibar.
 *   `suggestion_url` **[string][102]** the URL to fetch suggestions in omnibar when this search engine is triggered. (optional, default `null`)
 *   `callback_to_parse_suggestion` **[function][103]** a function to parse response from `suggestion_url` and return a list of strings as suggestions. (optional, default `null`)
 *   `only_this_site_key` **[string][102]** `<search_leader_key><only_this_site_key><alias>` in normal mode will search selected text within current site with this search engine directly without opening the omnibar, for example `sod`. (optional, default `o`)
+*   `options` **[object][104]** `favicon_url` URL for favicon for this search engine (optional, default `null`)
 
 ### Examples
 
@@ -457,6 +458,8 @@ mapkey('yA', '#7Copy a link URL to the clipboard', function() {
     });
 });
 ```
+
+Returns **[boolean][107]** whether any hint is created for target elements.
 
 ## Hints.dispatchMouseClick
 

--- a/src/content_scripts/common/api.js
+++ b/src/content_scripts/common/api.js
@@ -323,8 +323,8 @@ function createAPI(clipboard, insert, normal, hints, visual, front, browser) {
         dispatchSKEvent('addVimKeyMap', Array.from(arguments));
     }
 
-    function _addSearchAlias(alias, prompt, url, suggestionURL, listSuggestion) {
-        front.addSearchAlias(alias, prompt, url, suggestionURL, listSuggestion);
+    function _addSearchAlias(alias, prompt, url, suggestionURL, listSuggestion, options) {
+        front.addSearchAlias(alias, prompt, url, suggestionURL, listSuggestion, options);
     }
 
     function _removeSearchAlias(alias) {
@@ -341,6 +341,7 @@ function createAPI(clipboard, insert, normal, hints, visual, front, browser) {
      * @param {string} [suggestion_url=null] the URL to fetch suggestions in omnibar when this search engine is triggered.
      * @param {function} [callback_to_parse_suggestion=null] a function to parse response from `suggestion_url` and return a list of strings as suggestions.
      * @param {string} [only_this_site_key=o] `<search_leader_key><only_this_site_key><alias>` in normal mode will search selected text within current site with this search engine directly without opening the omnibar, for example `sod`.
+     * @param {object} [options=null] `favicon_url` URL for favicon for this search engine
      *
      * @example
      * addSearchAlias('d', 'duckduckgo', 'https://duckduckgo.com/?q=', 's', 'https://duckduckgo.com/ac/?q=', function(response) {
@@ -350,8 +351,8 @@ function createAPI(clipboard, insert, normal, hints, visual, front, browser) {
      *     });
      * });
      */
-    function addSearchAlias(alias, prompt, search_url, search_leader_key, suggestion_url, callback_to_parse_suggestion, only_this_site_key) {
-        _addSearchAlias(alias, prompt, search_url, suggestion_url, callback_to_parse_suggestion);
+    function addSearchAlias(alias, prompt, search_url, search_leader_key, suggestion_url, callback_to_parse_suggestion, only_this_site_key, options) {
+        _addSearchAlias(alias, prompt, search_url, suggestion_url, callback_to_parse_suggestion, options);
         function ssw() {
             searchSelectedWith(search_url);
         }

--- a/src/content_scripts/front.js
+++ b/src/content_scripts/front.js
@@ -57,7 +57,7 @@ function createFront(insert, normal, hints, visual, browser) {
     });
 
     var _listSuggestions = {};
-    self.addSearchAlias = function (alias, prompt, url, suggestionURL, listSuggestion) {
+    self.addSearchAlias = function (alias, prompt, url, suggestionURL, listSuggestion, options) {
         if (suggestionURL && listSuggestion) {
             _listSuggestions[suggestionURL] = listSuggestion;
         }
@@ -66,7 +66,8 @@ function createFront(insert, normal, hints, visual, browser) {
             alias: alias,
             prompt: prompt,
             url: url,
-            suggestionURL: suggestionURL
+            suggestionURL: suggestionURL,
+            options: options,
         });
     };
     self.removeSearchAlias = function (alias) {

--- a/src/content_scripts/ui/omnibar.js
+++ b/src/content_scripts/ui/omnibar.js
@@ -1291,10 +1291,20 @@ function SearchEngine(omnibar, front) {
         if (searchEngineIcon) {
             self.aliases[message.alias].prompt = `<img src="${searchEngineIcon}" alt=${message.prompt} style="width: 20px;" />`;
         } else if (front.topOrigin.startsWith("http")){
-            let origin = new URL(message.url).origin;
-            origin = origin.replace(/(https?:\/\/)([^.]*)\.([^.]*)\.([^.]*)/, new URL(front.topOrigin).protocol + "//www.$3.$4");
+            let iconUrl;
+            if (message.options?.favicon_url) {
+              iconUrl = new URL(message.options.favicon_url);
+            } else {
+              iconUrl = new URL(message.url);
+              iconUrl.pathname = "favicon.ico";
+              iconUrl.search = "";
+              iconUrl.hash = "";
+            }
+            if (iconUrl.protocol !== "data:") {
+              iconUrl.protocol = (new URL(front.topOrigin)).protocol;
+            }
             RUNTIME('requestImage', {
-                url: `${origin}/favicon.ico`
+                url: iconUrl.href,
             }, function(response) {
                 localStorage.setItem(searchEngineIconStorageKey, response.text);
                 self.aliases[message.alias].prompt = `<img src="${response.text}" alt=${message.prompt} style="width: 20px;" />`;


### PR DESCRIPTION
I really like the new Omnibar search engine icon feature!

One issue I had is that I have numerous search engines configured where the `search_url` does not match the site it's searching.

For example, I use a [Google Custom Search engine](https://developers.google.com/custom-search/) to search the Arch Linux forums, where the `search_url` is `https://cse.google.com/cse/publicurl?cx=xxxxx&q=`. With the old behavior, the Omnibar showed a Google favicon, but I want it to show an Arch Linux favicon. 

#### New Behavior

With this change, users calling `addSearchAlias` can directly specify the desired favicon via the `favicon_url` property of the new `options` argument. For example:

```javascript
addSearchAlias(
  'af', 
  'Arch Linux Forums', 
  'https://cse.google.com/cse/publicurl?cx=xxxxx&q=', 
  's', 
  'https://www.googleapis.com/customsearch/v1?key=xxxxx&cx=xxxxx&q=',
  function(response) {
    // ...
  },
  { favicon_url: 'https://archlinux.org/favicon.ico' },
);
```

This is also useful when a site's favicon isn't accessible at the standard `/favicon.ico` path. For example, Dribbble's [`/favicon.ico`](https://dribbble.com/favicon.ico) returns a 404 error; the actual favicon URL is `https://cdn.dribbble.com/assets/favicon-b38525134603b9513174ec887944bde1a869eb6cd414f4d640ee48ab2a15a26b.ico`.

Finally, this makes it possible to use an image encoded in a [data URI](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs) as a favicon, which is useful if you want to use a custom favicon that's not hosted on the web.

#### Implementation Notes

I added a new `options` argument to `api.addSearchAlias()` which accepts an object containing the `favicon_url` key. I took this approach rather than adding a single argument specifically for the new `favicon_url` option because the function signature was already getting very long. Accepting an `options` object will make it easier to add additional options in the future without making the signature even longer.