### PR TITLE
Fix cross-origin canvas tainting

### DIFF
--- a/src/background/start.js
+++ b/src/background/start.js
@@ -1162,6 +1162,7 @@ function start(browser) {
     };
     self.requestImage = function(message, sender, sendResponse) {
         const img = document.createElement("img");
+        img.crossOrigin = "Anonymous";
         img.src = message.url;
         img.onload = () => {
             const canvas = document.createElement('canvas');

--- a/src/content_scripts/ui/omnibar.js
+++ b/src/content_scripts/ui/omnibar.js
@@ -1300,9 +1300,6 @@ function SearchEngine(omnibar, front) {
               iconUrl.search = "";
               iconUrl.hash = "";
             }
-            if (iconUrl.protocol !== "data:") {
-              iconUrl.protocol = (new URL(front.topOrigin)).protocol;
-            }
             RUNTIME('requestImage', {
                 url: iconUrl.href,
             }, function(response) {


### PR DESCRIPTION
Canvas tainting can be avoided [by adding a `crossOrigin = "Anonymous"` prop to an image element](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image). This makes fetching images a lot more reliable. An added benefit is that secure images can even be loaded from an insecure top-origin, which makes `omnibar.js` lines `1303-1305` unnecessary.