### PR TITLE
Extend functionality of addSearchAlias suggestions

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -318,7 +318,7 @@ Add a search engine alias into Omnibar.
 *   `search_url` **[string][102]** the URL of the search engine
 *   `search_leader_key` **[string][102]** `<search_leader_key><alias>` in normal mode will search selected text with this search engine directly without opening the omnibar, for example `sd`. (optional, default `s`)
 *   `suggestion_url` **[string][102]** the URL to fetch suggestions in omnibar when this search engine is triggered. (optional, default `null`)
-*   `callback_to_parse_suggestion` **[function][103]** a function to parse response from `suggestion_url` and return a list of strings as suggestions. (optional, default `null`)
+*   `callback_to_parse_suggestion` **[function][103]** a function to parse the response from `suggestion_url` and return a list of strings as suggestions. Receives two arguments: `response`, the first argument, is an object containing a property `text` which holds the text of the response; and `request`, the second argument, is an object containing the properties `query` which is the text of the query and `url` which is the formatted URL for the request. (optional, default `null`)
 *   `only_this_site_key` **[string][102]** `<search_leader_key><only_this_site_key><alias>` in normal mode will search selected text within current site with this search engine directly without opening the omnibar, for example `sod`. (optional, default `o`)
 *   `options` **[object][104]** `favicon_url` URL for favicon for this search engine (optional, default `null`)
 

--- a/src/content_scripts/common/api.js
+++ b/src/content_scripts/common/api.js
@@ -339,7 +339,7 @@ function createAPI(clipboard, insert, normal, hints, visual, front, browser) {
      * @param {string} search_url the URL of the search engine
      * @param {string} [search_leader_key=s] `<search_leader_key><alias>` in normal mode will search selected text with this search engine directly without opening the omnibar, for example `sd`.
      * @param {string} [suggestion_url=null] the URL to fetch suggestions in omnibar when this search engine is triggered.
-     * @param {function} [callback_to_parse_suggestion=null] a function to parse response from `suggestion_url` and return a list of strings as suggestions.
+     * @param {function} [callback_to_parse_suggestion=null] a function to parse the response from `suggestion_url` and return a list of strings as suggestions. Receives two arguments: `response`, the first argument, is an object containing a property `text` which holds the text of the response; and `request`, the second argument, is an object containing the properties `query` which is the text of the query and `url` which is the formatted URL for the request.
      * @param {string} [only_this_site_key=o] `<search_leader_key><only_this_site_key><alias>` in normal mode will search selected text within current site with this search engine directly without opening the omnibar, for example `sod`.
      * @param {object} [options=null] `favicon_url` URL for favicon for this search engine
      *

--- a/src/content_scripts/front.js
+++ b/src/content_scripts/front.js
@@ -112,7 +112,10 @@ function createFront(insert, normal, hints, visual, browser) {
     _actions["getSearchSuggestions"] = function (message) {
         var ret = null;
         if (_listSuggestions.hasOwnProperty(message.url)) {
-            ret = _listSuggestions[message.url](message.response);
+            ret = _listSuggestions[message.url](message.response, {
+              url: message.requestUrl,
+              query: message.query,
+            });
         }
         return ret;
     };
@@ -640,12 +643,13 @@ function createFront(insert, normal, hints, visual, browser) {
             } else if (_message.commandToContent && _message.action && _actions.hasOwnProperty(_message.action)) {
                 var ret = _actions[_message.action](_message);
                 if (_message.ack) {
-                    runtime.postTopMessage({
-                        data: ret,
-                        responseToFrontend: true,
-                        origin: _message.origin,
-                        id: _message.id
-                    });
+                    Promise.resolve(ret).then((data) =>
+                      runtime.postTopMessage({
+                          data,
+                          responseToFrontend: true,
+                          origin: _message.origin,
+                          id: _message.id
+                      }));
                 }
             }
         } else if (_message.action === "activated") {

--- a/src/content_scripts/ui/omnibar.js
+++ b/src/content_scripts/ui/omnibar.js
@@ -1261,13 +1261,16 @@ function SearchEngine(omnibar, front) {
         // This helps prevent rate-limits when typing a long query.
         // E.g. github.com's API rate-limits after only 10 unauthenticated requests.
         _pendingRequest = setTimeout(function() {
+            const requestUrl = formatURL(self.suggestionURL, encodeURIComponent(omnibar.input.value));
             RUNTIME('request', {
                 method: 'get',
-                url: formatURL(self.suggestionURL, encodeURIComponent(omnibar.input.value))
+                url: requestUrl
             }, function (resp) {
                 front.contentCommand({
                     action: 'getSearchSuggestions',
                     url: self.suggestionURL,
+                    query: omnibar.input.value,
+                    requestUrl,
                     response: resp
                 }, function(resp) {
                     resp = resp.data;


### PR DESCRIPTION
A few enhancements to give searchAliases more flexibility:

- The suggestion callback now receives another argument: an object containing the original query and the formatted URL
- Suggestion callbacks can now return promises