### PR TITLE
Set correct doctype for frontend.html

### DIFF
--- a/src/content_scripts/ui/frontend.html
+++ b/src/content_scripts/ui/frontend.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">


### PR DESCRIPTION
This avoids warnings like `This page is in Quirks Mode. Page layout may be impacted. For Standards Mode use “<!DOCTYPE html>”. > frontend.html`