### PR TITLE
Move arbitrary tabs with RUNTIME("moveTabs")

### DIFF
--- a/src/background/start.js
+++ b/src/background/start.js
@@ -943,6 +943,11 @@ function start(browser) {
             });
         });
     };
+    self.moveTabs = function(message, sender, sendResponse) {
+        message.tabsToMove.forEach(function([tabId, moveParams]) {
+            chrome.tabs.move(tabId, moveParams);
+        });
+    };
     self.moveToWindow = function(message, sender, sendResponse) {
         if (message.windowId === -1) {
             chrome.windows.create({tabId: sender.tab.id});


### PR DESCRIPTION
I wanted to add a custom shortcut to move all tabs, which meet X criteria, to the left side of the tab bar.
But I wasn't able to do so with the existing RUNTIME handlers, since they largely rely on moving the active tab.

Didn't spend much time on the API for this handler yet, open to suggestions if you have any

Currently it expects a list of "tuples" (tabId, moveParams)
and moveParams is passed directly as the second arg to chrome.tabs.move for maximum flexibility

``` javascript
api.RUNTIME("moveTabs", [
  [tabId1, { index: -1 }]
])
```