### PR TITLE
Search selected/entered via omnibar on background

### DIFF
--- a/src/content_scripts/common/api.js
+++ b/src/content_scripts/common/api.js
@@ -352,7 +352,9 @@ function createAPI(clipboard, insert, normal, hints, visual, front, browser) {
      * });
      */
     function addSearchAlias(alias, prompt, search_url, search_leader_key, suggestion_url, callback_to_parse_suggestion, only_this_site_key, options) {
+        var background_tab_key = ';'; // TODO
         _addSearchAlias(alias, prompt, search_url, suggestion_url, callback_to_parse_suggestion, options);
+
         function ssw() {
             searchSelectedWith(search_url);
         }
@@ -361,11 +363,18 @@ function createAPI(clipboard, insert, normal, hints, visual, front, browser) {
             front.openOmnibar({type: "SearchEngine", extra: alias});
         });
         vmapkey((search_leader_key || 's') + alias, '', ssw);
+
         function ssw2() {
             searchSelectedWith(search_url, true);
         }
         mapkey((search_leader_key || 's') + (only_this_site_key || 'o') + alias, '', ssw2);
         vmapkey((search_leader_key || 's') + (only_this_site_key || 'o') + alias, '', ssw2);
+
+        function ssw3(){
+            searchSelectedWith(search_url, false, false, "", true)
+        }
+        mapkey((search_leader_key || 's') + (background_tab_key || 'b') + alias, '', ssw3);
+        vmapkey((search_leader_key || 's') + (background_tab_key || 'b') + alias, '', ssw3);
 
         var capitalAlias = alias.toUpperCase();
         if (capitalAlias !== alias) {
@@ -416,11 +425,12 @@ function createAPI(clipboard, insert, normal, hints, visual, front, browser) {
      * @param {boolean} [onlyThisSite=false] whether to search only within current site, need support from the provided search engine.
      * @param {boolean} [interactive=false] whether to search in interactive mode, in case that you need some small modification on the selected content.
      * @param {string} [alias=""] only used with interactive mode, in such case the url from `se` is ignored, SurfingKeys will construct search URL from the alias registered by `addSearchAlias`.
+     * @param {boolean} [inBackground=false] open selected text in a not focused (background) tab
      *
      * @example
      * searchSelectedWith('https://translate.google.com/?hl=en#auto/en/');
      */
-    function searchSelectedWith(se, onlyThisSite, interactive, alias) {
+    function searchSelectedWith(se, onlyThisSite, interactive, alias, inBackground=false) {
         clipboard.read(function(response) {
             var query = window.getSelection().toString() || response.data;
             if (onlyThisSite) {
@@ -429,7 +439,7 @@ function createAPI(clipboard, insert, normal, hints, visual, front, browser) {
             if (interactive) {
                 front.openOmnibar({type: "SearchEngine", extra: alias, pref: query});
             } else {
-                tabOpenLink(constructSearchURL(se, encodeURIComponent(query)));
+                tabOpenLink(constructSearchURL(se, encodeURIComponent(query)), 5,inBackground); // TODO
             }
         });
     }

--- a/src/content_scripts/common/utils.js
+++ b/src/content_scripts/common/utils.js
@@ -582,6 +582,7 @@ function constructSearchURL(se, word) {
  *
  * @param {string} str links to be opened, the links should be split by `\n` if there are more than one.
  * @param {number} [simultaneousness=5] how many tabs will be opened simultaneously, the rest will be queued and opened later whenever a tab is closed.
+ * @param {boolean} [inBackground=false] open link in background
  *
  * @example
  * mapkey("<Space>", "pause/resume on youtube", function() {
@@ -589,7 +590,7 @@ function constructSearchURL(se, word) {
  *     btn.click();
  * }, {domain: /youtube.com/i});
  */
-function tabOpenLink(str, simultaneousness) {
+function tabOpenLink(str, simultaneousness,inBackground = false) {
     simultaneousness = simultaneousness || 5;
 
     var urls;
@@ -612,7 +613,8 @@ function tabOpenLink(str, simultaneousness) {
     urls.slice(0, simultaneousness).forEach(function(url) {
         RUNTIME("openLink", {
             tab: {
-                tabbed: true
+                tabbed: true,
+                active: !inBackground
             },
             url: url
         });


### PR DESCRIPTION
Sometimes it feels natural to accumulate links in the background to read them later. 

Solves #1757

Functionality is ready but I want to discuss defaults and some refactorings.

1. What should be the default key for searching in the background?
I choose `;` because it's unlikely to someone assign `searchAlias` to `;`. `b` for _"background"_ is occupied by default and even if the user changes it'll probably clash with Baidu or Bing.

2. Should we refactor?
I think it's sufficiently hard to grasp which line adds what functionality in the current state.
For `o` + `alias` like `og` for _"Open Google"_ `Control + Enter` opens in background so one Omnibar is enough. But other parts have some repetitions, we can use some kind of builder, but to use a builder we  need to change `searchSelectedWith` to something like `searchSelectedWith(URL: string, options: {})`
