### PR TITLE
prevent `gxx` from closing pinned tabs

### DIFF
--- a/src/background/start.js
+++ b/src/background/start.js
@@ -900,9 +900,9 @@ function start(browser) {
     };
     self.tabOnly = function(message, sender, sendResponse) {
         chrome.tabs.query({currentWindow: true}, function(tabs) {
-            tabs = tabs.map(function(e) { return e.id; }).filter(function(t) {
-                return t != sender.tab.id;
-            });
+            tabs = tabs.filter(function(t) {
+                return t.id != sender.tab.id && !t.pinned;
+            }).map(function(t) { return t.id });
             chrome.tabs.remove(tabs);
         });
     };


### PR DESCRIPTION
`gxx` is bound to the 'close all tabs but the current one' action

`gxx` also closes pinned tabs, which in my opinion could be unwanted. Pinned tabs are meant to be more permanent

Tested with `browser=firefox npm run build:dev` on Firefox Nightly