### PR TITLE
Added 'yL' to copy current tab's url in markdown format

### DIFF
--- a/src/content_scripts/common/default.js
+++ b/src/content_scripts/common/default.js
@@ -249,6 +249,9 @@ module.exports = function(api) {
     mapkey('yl', "#7Copy current page's title", function() {
         Clipboard.write(document.title);
     });
+    mapkey('yL', "#7Copy current page's url in markdown format", function() {
+        Clipboard.write( '[' + document.title + '](' + window.location.href + ')');
+    });
     mapkey('yQ', '#7Copy all query history of OmniQuery.', function() {
         RUNTIME('getSettings', {
             key: 'OmniQueryHistory'


### PR DESCRIPTION
https://github.com/brookhong/Surfingkeys/issues/1801 
Added `yL` to copy current tab's url in markdown format `[title](url)` 

Or if any suggestion for a better keybinding?
