### PR TITLE
Add options property skipMaps to addSearchAlias

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -320,7 +320,7 @@ Add a search engine alias into Omnibar.
 *   `suggestion_url` **[string][102]** the URL to fetch suggestions in omnibar when this search engine is triggered. (optional, default `null`)
 *   `callback_to_parse_suggestion` **[function][103]** a function to parse the response from `suggestion_url` and return a list of strings as suggestions. Receives two arguments: `response`, the first argument, is an object containing a property `text` which holds the text of the response; and `request`, the second argument, is an object containing the properties `query` which is the text of the query and `url` which is the formatted URL for the request. (optional, default `null`)
 *   `only_this_site_key` **[string][102]** `<search_leader_key><only_this_site_key><alias>` in normal mode will search selected text within current site with this search engine directly without opening the omnibar, for example `sod`. (optional, default `o`)
-*   `options` **[object][104]** `favicon_url` URL for favicon for this search engine (optional, default `null`)
+*   `options` **[object][104]** `favicon_url` URL for favicon for this search engine, `skipMaps` if `true` disable creating key mappings for this search engine (optional, default `null`)
 
 ### Examples
 

--- a/src/content_scripts/common/api.js
+++ b/src/content_scripts/common/api.js
@@ -344,7 +344,7 @@ function createAPI(clipboard, insert, normal, hints, visual, front, browser) {
      * @param {string} [suggestion_url=null] the URL to fetch suggestions in omnibar when this search engine is triggered.
      * @param {function} [callback_to_parse_suggestion=null] a function to parse the response from `suggestion_url` and return a list of strings as suggestions. Receives two arguments: `response`, the first argument, is an object containing a property `text` which holds the text of the response; and `request`, the second argument, is an object containing the properties `query` which is the text of the query and `url` which is the formatted URL for the request.
      * @param {string} [only_this_site_key=o] `<search_leader_key><only_this_site_key><alias>` in normal mode will search selected text within current site with this search engine directly without opening the omnibar, for example `sod`.
-     * @param {object} [options=null] `favicon_url` URL for favicon for this search engine
+     * @param {object} [options=null] `favicon_url` URL for favicon for this search engine, `skipMaps` if `true` disable creating key mappings for this search engine
      *
      * @example
      * addSearchAlias('d', 'duckduckgo', 'https://duckduckgo.com/?q=', 's', 'https://duckduckgo.com/ac/?q=', function(response) {
@@ -356,6 +356,10 @@ function createAPI(clipboard, insert, normal, hints, visual, front, browser) {
      */
     function addSearchAlias(alias, prompt, search_url, search_leader_key, suggestion_url, callback_to_parse_suggestion, only_this_site_key, options) {
         _addSearchAlias(alias, prompt, search_url, suggestion_url, callback_to_parse_suggestion, options);
+        const skipMaps = options?.skipMaps ?? false
+        if (skipMaps) {
+          return
+        }
         function ssw() {
             searchSelectedWith(search_url);
         }


### PR DESCRIPTION
If the `skipMaps` property of `addSearchAlias`'s `options` argument is `true`, key mappings will not be created for the search alias. This is useful in my config because I want to create the mappings myself.