### PR TITLE
Support custom copy text for Omnibar results

### DIFF
--- a/src/content_scripts/ui/omnibar.js
+++ b/src/content_scripts/ui/omnibar.js
@@ -150,10 +150,17 @@ function createOmnibar(front, clipboard) {
             self.input.style.display = "none";
 
             const fi = self.resultsDiv.querySelector('li.focused');
-            const url = (fi && fi.url) ? fi.url : _page.map(p => {
-                return p.url;
-            }).join("\n");
-            clipboard.write(url);
+            let text;
+            if (fi && fi.copy) {
+                text = fi.copy;
+            } else if (fi && fi.url) {
+                text = fi.url;
+            } else {
+                text = _page.map(p => {
+                    return p.url;
+                }).join("\n")
+            }
+            clipboard.write(text);
 
             self.input.style.display = "";
         }


### PR DESCRIPTION
If an Omnibar result has a `props.copy` property, it will be copied to the clipboard when the user presses `<Ctrl-c>` on the result item. If both `props.copy` and `props.url` are present, `props.copy` takes precedence.

I'm using this in my config for a Unicode searchAlias that I've made: https://github.com/b0o/surfingkeys-conf/blob/6b6eba4c564953b77d535416f1c0f9752e879a60/src/search-engines.js#L398-L417

![screenshot](https://raw.githubusercontent.com/b0o/surfingkeys-conf/main/assets/screenshots/un.png)