### PR TITLE
Fix: Ensure selected Omnibar item is scrolled into view

### DIFF
--- a/src/content_scripts/ui/omnibar.js
+++ b/src/content_scripts/ui/omnibar.js
@@ -277,7 +277,12 @@ function createOmnibar(front, clipboard) {
         }
         if (fi) {
             fi.classList.add('focused');
-            scrollIntoViewIfNeeded(fi);
+            const fiRect = fi.getBoundingClientRect();
+            const resultsRect = self.resultsDiv.getBoundingClientRect();
+            if (fiRect.top < resultsRect.top || fiRect.bottom > resultsRect.bottom) {
+              const alignToTop = fiRect.top < resultsRect.top;
+              fi.scrollIntoView(alignToTop);
+            }
         }
     };
 


### PR DESCRIPTION
### Prior behavior

https://user-images.githubusercontent.com/21299126/201510317-8eb55970-3884-4ba8-8a43-6fe923881f8c.mp4

Previously, when using the arrow keys or tab/shift+tab to select an Omnibar result item, scroll behavior was broken in Firefox and glitchy in Chrome.

In Firefox, if there were more results than could fit in the Omnibar results div, selecting a result item outside of the visible portion of the results div would not cause the result item to be scrolled into view unless the result item was below the bottom of the viewport. This would often cause the selected item to be invisible.

In Chrome, if there were more results than could fit into the Omnibar results div, selecting a result item outside of the visible portion of the results div would sometimes cause the result item to be scrolled just barely into view, and other times would cause the item to be scrolled to the center of the results div. This felt like poor UX.

### New behavior

https://user-images.githubusercontent.com/21299126/201510404-fa51992c-e6f8-456d-8536-7b7fdf45af08.mp4

Now, Chrome and Firefox should behave the same.

When an Omnibar result item is selected, we check if the top of the item is above the top of the results div, or if the bottom of the item is below the bottom of the results div. If either condition is true, we scroll the result item into view.

---

Tested in Chromium and Firefox on Linux. Not tested in Safari.