### PR TITLE
Support light and dark color scheme

### DIFF
--- a/src/content_scripts/ui/frontend.html
+++ b/src/content_scripts/ui/frontend.html
@@ -2,6 +2,7 @@
 <html>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="color-scheme" content="dark light">
     <link rel="stylesheet" href="frontend.css">
     <link rel="stylesheet" href="../content.css">
 </head>

--- a/src/content_scripts/uiframe.js
+++ b/src/content_scripts/uiframe.js
@@ -7,7 +7,6 @@ function createUiHost(browser, onload) {
     var uiHost = document.createElement("div");
     uiHost.style.display = "block";
     uiHost.style.opacity = 1;
-    uiHost.style.colorScheme = "light";
     var frontEndURL = chrome.runtime.getURL('pages/frontend.html');
     var ifr = document.createElement("iframe");
     ifr.setAttribute('allowtransparency', true);


### PR DESCRIPTION
### Background

Months ago, issue #1719 was opened, reporting that Surfingkeys was causing the page to become blank in Safari when dark mode was active. This was resolved in ccedde8 by setting `color-scheme: light` on the Surfingkeys container div.

ccedde8 fixed the original issue, but it created a new issue that the Surfingkeys iframe would always be using `color-scheme: light`. This meant that the user couldn't use `@media(prefers-color-scheme: dark)` in their custom themes, at least in Firefox.

### The interaction between color-scheme and transparent iframes

The way browsers handle color-scheme in combination with transparent iframes is nuanced. The CSSWG [decided](https://github.com/w3c/csswg-drafts/issues/4772#issuecomment-591553929) that "_if the color scheme of an iframe differs from embedding document, the iframe gets an opaque canvas bg appropriate to its color scheme_". I believe this behavior is what was causing #1719 in the first place. I found a good [blog post](https://fvsch.com/transparent-iframes) explaining these behaviors.

### This PR

Instead of setting `color-scheme: light` on the Surfingkeys container div, this PR adds a `meta` tag to the Surfingkeys iframe, declaring that it supports both `light` and `dark` mode. In my testing in Firefox, this solves both problems: no white blank page, and the user can use `prefers-color-scheme` media queries.

I tried testing this in Safari 14.1.2 on macOS 11.6.8 - I was not able to reproduce the original bug, but it seems this change works fine. (Note: I tested this manually in the devtools in Safari, I didn't build the extension with this change for Safari). I'd appreciate if you could test this in Safari on macOS and also iPadOS, to ensure that it works properly in those places before merging.
