### PR TITLE
add link to wiki and FAQ in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,6 +580,7 @@ Some functionalities are also available when you're using original pdf viewer, b
 ## Other
 
 * [Anki Study Deck](https://ankiweb.net/shared/info/1195173768), Anki Study Deck (helpful for memorizing keyboard mappings) 
+* For further information check out the [FAQ](https://github.com/brookhong/Surfingkeys/wiki/FAQ) and add to the user-contributed documentation on the [Surfingkeys Wiki](https://github.com/brookhong/Surfingkeys/wiki/).
 
 ## Credits
 


### PR DESCRIPTION
It's not obvious from the github interface that there's an active wiki (other than the wiki tab appearing on the repo page), so it would be helpful to specifically mention both the FAQ and wiki in the README.md. I never would have found it if it weren't for someone pointing it out to me in a comment on an issue.