### PR TITLE
CodeMirror vim editor support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage/
 package-lock.json
 jsconfig.json
 src/content_scripts/safari.js
+*~

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Surfingkeys",
-  "version": "1.12",
+  "version": "1.12.0",
   "description": "Map your keys for web surfing, expand your browser with javascript and keyboard.",
   "main": "background.js",
   "directories": {
@@ -68,6 +68,7 @@
     "@pixi/ticker": "^6.2.1",
     "@pixi/unsafe-eval": "^6.2.1",
     "@pixi/utils": "^6.2.1",
+    "@pixi/extensions": "^6.2.1",
     "ace-builds": "^1.4.12",
     "dompurify": "^2.3.1",
     "js-base64": "^3.7.2",

--- a/src/content_scripts/common/insert.js
+++ b/src/content_scripts/common/insert.js
@@ -32,12 +32,38 @@ function createInsert() {
                 if (node.nodeType === Node.TEXT_NODE) {
                     document.getSelection().setPosition(node, node.data.length);
                 } else {
-                    document.getSelection().setPosition(node, node.childNodes.length);
+                    let codeMirrorNode = node.querySelector(".CodeMirror-line")
+                    if (codeMirrorNode) {
+                        setEndOfContenteditable(element)
+                    } else {
+                        document.getSelection().setPosition(node, node.childNodes.length);
+                    }
                 }
                 // blink cursor to bring cursor into view
                 Visual.showCursor();
                 Visual.hideCursor();
             }
+        }
+    }
+
+    // From https://stackoverflow.com/questions/1125292/how-to-move-cursor-to-end-of-contenteditable-entity/69727327#69727327
+    function setEndOfContenteditable(contentEditableElement) {
+        var range, selection;
+        if(document.createRange)//Firefox, Chrome, Opera, Safari, IE 9+
+        {
+            range = document.createRange();//Create a range (a range is a like the selection but invisible)
+            range.selectNodeContents(contentEditableElement);//Select the entire contents of the element with the range
+            range.collapse(false);//collapse the range to the end point. false means collapse to end rather than the start
+            selection = window.getSelection();//get the selection object (allows you to change selection)
+            selection.removeAllRanges();//remove any selections already made
+            selection.addRange(range);//make the range you have just created the visible selection
+        }
+        else if(document.selection)//IE 8 and lower
+        {
+            range = document.body.createTextRange();//Create a range (a range is a like the selection but invisible)
+            range.moveToElementText(contentEditableElement);//Select the entire contents of the element with the range
+            range.collapse(false);//collapse the range to the end point. false means collapse to end rather than the start
+            range.select();//Select the range (make it the visible selection)
         }
     }
 

--- a/src/content_scripts/common/insert.js
+++ b/src/content_scripts/common/insert.js
@@ -48,23 +48,12 @@ function createInsert() {
 
     // From https://stackoverflow.com/questions/1125292/how-to-move-cursor-to-end-of-contenteditable-entity/69727327#69727327
     function setEndOfContenteditable(contentEditableElement) {
-        var range, selection;
-        if(document.createRange)//Firefox, Chrome, Opera, Safari, IE 9+
-        {
-            range = document.createRange();//Create a range (a range is a like the selection but invisible)
-            range.selectNodeContents(contentEditableElement);//Select the entire contents of the element with the range
-            range.collapse(false);//collapse the range to the end point. false means collapse to end rather than the start
-            selection = window.getSelection();//get the selection object (allows you to change selection)
-            selection.removeAllRanges();//remove any selections already made
-            selection.addRange(range);//make the range you have just created the visible selection
-        }
-        else if(document.selection)//IE 8 and lower
-        {
-            range = document.body.createTextRange();//Create a range (a range is a like the selection but invisible)
-            range.moveToElementText(contentEditableElement);//Select the entire contents of the element with the range
-            range.collapse(false);//collapse the range to the end point. false means collapse to end rather than the start
-            range.select();//Select the range (make it the visible selection)
-        }
+        let range = document.createRange();//Create a range (a range is a like the selection but invisible)
+        range.selectNodeContents(contentEditableElement);//Select the entire contents of the element with the range
+        range.collapse(false);//collapse the range to the end point. false means collapse to end rather than the start
+        let selection = window.getSelection();//get the selection object (allows you to change selection)
+        selection.removeAllRanges();//remove any selections already made
+        selection.addRange(range);//make the range you have just created the visible selection
     }
 
     self.mappings = new Trie();

--- a/src/content_scripts/common/insert.js
+++ b/src/content_scripts/common/insert.js
@@ -13,7 +13,7 @@ import {
 function createInsert() {
     var self = new Mode("Insert");
 
-    function moveCusorEOL() {
+    function moveCursorEOL() {
         var element = getRealEdit();
         if (element.setSelectionRange !== undefined) {
             try {
@@ -46,7 +46,7 @@ function createInsert() {
     self.mappings.add(KeyboardUtils.encodeKeystroke("<Ctrl-e>"), {
         annotation: "Move the cursor to the end of the line",
         feature_group: 15,
-        code: moveCusorEOL
+        code: moveCursorEOL
     });
     self.mappings.add(KeyboardUtils.encodeKeystroke("<Ctrl-f>"), {
         annotation: "Move the cursor to the beginning of the line",
@@ -434,7 +434,7 @@ function createInsert() {
             changed = true;
         }
         if (changed && !keepCursor && runtime.conf.cursorAtEndOfInput && elm.nodeName !== 'SELECT') {
-            moveCusorEOL();
+            moveCursorEOL();
         }
     };
 

--- a/src/content_scripts/front.js
+++ b/src/content_scripts/front.js
@@ -229,11 +229,19 @@ function createFront(insert, normal, hints, visual, browser) {
         // setEditorText and setValueWithEventDispatched are experimental APIs from Brook Build of Chromium
         // https://brookhong.github.io/2021/04/18/brook-build-of-chromium.html
         if (elementBehindEditor.nodeName === "DIV") {
-            data = data.replace(/\n+$/, '');
-            if (typeof elementBehindEditor.setEditorText === "function") {
-                elementBehindEditor.setEditorText(data);
+            if (elementBehindEditor.className === "CodeMirror-code") {
+                window.getSelection().selectAllChildren(elementBehindEditor)
+                let dataTransfer = new DataTransfer()
+                dataTransfer.items.add(data, 'text/plain')
+                elementBehindEditor.dispatchEvent(new ClipboardEvent('paste', {clipboardData: dataTransfer}))
             } else {
-                elementBehindEditor.innerText = data;
+                data = data.replace(/\n+$/, '');
+
+                if (typeof elementBehindEditor.setEditorText === "function") {
+                    elementBehindEditor.setEditorText(data);
+                } else {
+                    elementBehindEditor.innerText = data;
+                }
             }
         } else {
             if (typeof elementBehindEditor.setValueWithEventDispatched === "function") {

--- a/src/content_scripts/front.js
+++ b/src/content_scripts/front.js
@@ -295,6 +295,9 @@ function createFront(insert, normal, hints, visual, browser) {
                 if (elementBehindEditor.className === "CodeMirror-code") {
                     let codeMirrorLines = elementBehindEditor.querySelectorAll(".CodeMirror-line")
                     content = Array.from(codeMirrorLines).map(el => el.innerText).join("\n")
+                    // Remove the red dot (char code 8226) that CodeMirror uses to visualize the zero-width space.
+                    content = content.replace(/\u200B/g, "")
+
                 } else {
                     content = elementBehindEditor.innerText;
                 }

--- a/src/content_scripts/front.js
+++ b/src/content_scripts/front.js
@@ -292,7 +292,12 @@ function createFront(insert, normal, hints, visual, browser) {
         } else {
             elementBehindEditor = element;
             if (elementBehindEditor.nodeName === "DIV") {
-                content = elementBehindEditor.innerText;
+                if (elementBehindEditor.className === "CodeMirror-code") {
+                    let codeMirrorLines = elementBehindEditor.querySelectorAll(".CodeMirror-line")
+                    content = Array.from(codeMirrorLines).map(el => el.innerText).join("\n")
+                } else {
+                    content = elementBehindEditor.innerText;
+                }
             } else {
                 content = elementBehindEditor.value;
             }


### PR DESCRIPTION
This PR adds support for editing text within CodeMirror elements. It does so by dispatching a clipboard paste event on the CodeMirror element. The event doesn't interact with the contents of the user's actual clipboard, it's just a synthetic event that transports the text from the vim editor modal to the CodeMirror element.

As an aside, there are two additional areas to look into at some point:
1. ~~After the paste event occurs, the cursor in the CodeMirror element moves from the end of the pasted text back to the beginning of the pasted text. I'm not sure what's provoking the cursor to move to the beginning of the line.~~
2. ~~When editing the contents of a CodeMirror element that contains line numbers (gist editor), those line numbers are brought into the vim editor as if they were text. I imagine this can be fixed by locating where in the code the text is selected and adding a filter to filter out elements with the `CodeMirror-linenumber` class.~~

Addresses issue #140.

EDIT: Fixed items 1 and 2.