### PR TITLE
add openWindow with oo mapping

### DIFF
--- a/src/background/start.js
+++ b/src/background/start.js
@@ -1611,6 +1611,10 @@ function start(browser) {
         chrome.tts.stop();
     };
 
+    self.openWindow = function(message, sender, sendResponse) {
+        chrome.windows.create({"url": message.url, "incognito": message.incognito});
+    };
+
     self.openIncognito = function(message, sender, sendResponse) {
         chrome.windows.create({"url": message.url, "incognito": true});
     };

--- a/src/content_scripts/common/default.js
+++ b/src/content_scripts/common/default.js
@@ -178,9 +178,16 @@ module.exports = function(api) {
     mapkey('r', '#4Reload the page', function() {
         RUNTIME("reloadTab", { nocache: false });
     });
+    mapkey('oo', '#8Open new window', function() {
+        RUNTIME('openWindow', {
+            url: window.location.href,
+            incognito: false
+        });
+    });
     mapkey('oi', '#8Open incognito window', function() {
-        RUNTIME('openIncognito', {
-            url: window.location.href
+        RUNTIME('openWindow', {
+            url: window.location.href,
+            incognito: true
         });
     });
 


### PR DESCRIPTION
Hello, thank you for the fantastic extension!

This PR adds an `openWindow` function as per `openIncognito`. This allows the user to open a normal window in addition to an incognito window.

Mapped default to `oo` - please suggest an alternative.

Tested on firefox with defaults and
```js
mapkey('w', '#8Open window', function() {
	api.RUNTIME('openWindow', { url: 'file:///home/alex/.blank.html', incognito: false });
});
mapkey('W', '#8Open incognito window', function() {
	api.RUNTIME('openWindow', { url: 'file:///home/alex/.blank.html', incognito: true });
});
```