### PR TITLE
add trim() to searching keywords

### DIFF
--- a/src/content_scripts/common/api.js
+++ b/src/content_scripts/common/api.js
@@ -431,6 +431,7 @@ function createAPI(clipboard, insert, normal, hints, visual, front, browser) {
     function searchSelectedWith(se, onlyThisSite, interactive, alias) {
         clipboard.read(function(response) {
             var query = window.getSelection().toString() || response.data;
+            query = query.trim();
             if (onlyThisSite) {
                 query = "site:" + window.location.hostname + " " + query;
             }


### PR DESCRIPTION
remove extra unvisual characters, especially line break