### PR TITLE
simplify selection items in vim editor (#2003)

### DIFF
--- a/src/content_scripts/front.js
+++ b/src/content_scripts/front.js
@@ -286,7 +286,12 @@ function createFront(insert, normal, hints, visual, browser) {
                 if (n.value === selected) {
                     initial_line = i;
                 }
-                return n.innerText.trim() + " >< " + n.value;
+                var text = n.innerText.trim();
+                if (text == n.value) {
+                    return text;
+                } else {
+                    return text + " >< " + n.value;
+                }
             }).join('\n');
             elementBehindEditor = element;
         } else {

--- a/src/content_scripts/ui/frontend.js
+++ b/src/content_scripts/ui/frontend.js
@@ -1018,8 +1018,8 @@ function createAceEditor(normal, front) {
         if (_editorType === 'select') {
             // get current line
             val = _ace.session.getLine(_ace.selection.lead.row);
-            val = val.match(/.*>< ([^<]*)$/);
-            val = val ? val[1] : "";
+            val = val.match(/^(.+ >< )?([^<>]+)$/);
+            val = val ? val[2] : "";
         }
         return val;
     }


### PR DESCRIPTION
For example:

~~~
  foo >< foo
  BAR >< bar
~~~

will be simplified as

~~~
  foo
  BAR >< bar
~~~