### PR TITLE
Expose `Front.showEditor` again

### DIFF
--- a/src/content_scripts/common/api.js
+++ b/src/content_scripts/common/api.js
@@ -505,6 +505,7 @@ function createAPI(clipboard, insert, normal, hints, visual, front, browser) {
         Front: {
             openOmnibar: front.openOmnibar,
             registerInlineQuery: front.registerInlineQuery,
+            showEditor: front.showEditor,
             showBanner,
             showPopup,
         },

--- a/src/content_scripts/front.js
+++ b/src/content_scripts/front.js
@@ -245,8 +245,7 @@ function createFront(insert, normal, hints, visual, browser) {
 
     var onEditorSaved, elementBehindEditor;
 
-    /* INGORE this from JSDOC
-     * Launch the vim editor.
+    /* Launch the vim editor.
      *
      * @param {HTMLElement} element the target element which the vim editor is launched for, this parameter can also be a string, which will be used as default content in vim editor.
      * @param {function} onWrite a callback function to be executed on written back from vim editor.

--- a/src/user_scripts/index.js
+++ b/src/user_scripts/index.js
@@ -211,6 +211,9 @@ const api = {
         openOmnibar: (args) => {
             dispatchSKEvent('api', ['front:openOmnibar', args]);
         },
+        showEditor: (element, onWrite, type, useNeovim) => {
+            dispatchSKEvent('api', ['front:showEditor', element, onWrite, type, useNeovim]);
+        },
         showBanner,
         showPopup
     },


### PR DESCRIPTION
It seems that `Front.showEditor` is no longer exported - probably as a result of 728e01168b800d6e83909642558b8327c186d65e.

See: https://github.com/brookhong/Surfingkeys/issues/2183
See: https://github.com/b0o/surfingkeys-conf/issues/89