### PR TITLE
fix: mru order tab last accessed

### DIFF
--- a/src/background/start.js
+++ b/src/background/start.js
@@ -745,8 +745,8 @@ function start(browser) {
                 });
                 tabs.sort(function(x, y) {
                     // Shift tabs without "last access" data to the end
-                    var a = tabActivated[x.id];
-                    var b = tabActivated[y.id];
+                    var a = x.lastAccessed || tabActivated[x.id];
+                    var b = y.lastAccessed || tabActivated[y.id];
 
                     if (!isFinite(a) && !isFinite(b)) {
                         return 0;


### PR DESCRIPTION
resolves https://github.com/brookhong/Surfingkeys/issues/2210

utilize tab's lastAccessed information if available for MRU order