### PR TITLE
change Ctrl-f to Ctrl-a

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ All mappings added with `imapkey` work in this mode.
 * `Ctrl - i` to open vim editor to edit.
 * `Ctrl - '` to toggle quotes in an input element, this is useful for search engines like google.
 * `Ctrl-e` move the cursor to the end of the line.
-* `Ctrl-f` move the cursor to the beginning of the line.
+* `Ctrl-a` move the cursor to the beginning of the line.
 * `Ctrl-u` delete all entered characters before the cursor.
 * `Alt-b` move the cursor Backward 1 word.
 * `Alt-f` move the cursor Forward 1 word.

--- a/README_CN.md
+++ b/README_CN.md
@@ -142,7 +142,7 @@ Surfingkeys有三种模式：normal，visual和insert。
 * `Ctrl - i` 打开vim编辑器。
 * `Ctrl - '` 把输入框里的内容用双引号引起来或去除双引号，方便在搜索引擎页面上搜索时使用。
 * `Ctrl-e`移动光标到行尾。
-* `Ctrl-f` 移动光标到行首。
+* `Ctrl-a` 移动光标到行首。
 * `Ctrl-u` 删除光标前所有输入。
 * `Alt-b` 移动光标到后一个词。
 * `Alt-f` 移动光标到前一个词。

--- a/src/content_scripts/common/insert.js
+++ b/src/content_scripts/common/insert.js
@@ -61,7 +61,7 @@ function createInsert() {
         feature_group: 15,
         code: moveCursorEOL
     });
-    self.mappings.add(KeyboardUtils.encodeKeystroke("<Ctrl-f>"), {
+    self.mappings.add(KeyboardUtils.encodeKeystroke("<Ctrl-a>"), {
         annotation: "Move the cursor to the beginning of the line",
         feature_group: 15,
         code: function() {


### PR DESCRIPTION
In Insert mode, Ctrl-f is to move the cursor to the beginning of the line. Can I remove the occupation of Ctrl-f and use Ctrl-a instead? Can this be the same as the shortcut keys in emacs?

https://github.com/brookhong/Surfingkeys/issues/2269