### PR TITLE
Fix: #2294 Hints overflow the page

### DIFF
--- a/src/content_scripts/common/hints.js
+++ b/src/content_scripts/common/hints.js
@@ -193,6 +193,10 @@ div.hint-scrollable {
 [mode=input] mask.activeInput {
     background: rgba(0, 0, 255, 0.25);
 }`);
+    /* When the <style> loaded, set host's height */
+    hintsStyle.onload = () =>
+        { hintsHost.style.height = `${window.scrollY + window.innerHeight}px`; }
+
     hintsHost.shadowRoot.appendChild(hintsStyle);
     const regionalHints = createRegionalHints(clipboard);
 

--- a/src/content_scripts/content.css
+++ b/src/content_scripts/content.css
@@ -2,7 +2,9 @@ div.surfingkeys_hints_host {
     display: block;
     opacity: 1;
     color-scheme: auto;
-    position: static;
+    position: absolute;
+    inset: 0 0 auto 0;
+    overflow: hidden;
 }
 div.surfingkeys_match_mark {
     background-color: #ff0;


### PR DESCRIPTION
Fixes #2294
### src/content_scripts/content.css
`div.surfingkeys_hints_host` has the `position: absolute` now
It is stretched over the **entire width of the page** and is located **at the top** of it. The height will be definied via JS
**Hints** are relative to the `div.surfingkeys_hints_host`. Therefore, **overflow** affects them now

### src/content_scripts/common/hints.js
The height of the `div.surfingkeys_hints_host` equals to the number of pixels **from the top the page** to the **bottom of the user's view port**

### Result
| Before | After |
| - | - |
| ![2025 05 18-01-27-57](https://github.com/user-attachments/assets/6ac01dc2-e001-4f68-89ff-eb75fc8aaa17) | ![2025 05 18-01-28-55](https://github.com/user-attachments/assets/ca43c245-dd68-4432-8b20-e957a776dfce) |
| ![2025 05 18-01-44-09](https://github.com/user-attachments/assets/36b5df2b-f492-4438-869a-027718649cf5) |![2025 05 18-01-44-51](https://github.com/user-attachments/assets/d87dac72-0f5e-414c-a6d6-3434b40f0e3a) |

