### PR TITLE
Fix: overflow-x hints behaviour (#2304)

### DIFF
--- a/src/content_scripts/common/hints.js
+++ b/src/content_scripts/common/hints.js
@@ -193,9 +193,18 @@ div.hint-scrollable {
 [mode=input] mask.activeInput {
     background: rgba(0, 0, 255, 0.25);
 }`);
-    /* When the <style> loaded, set host's height */
-    hintsStyle.onload = () =>
-        { hintsHost.style.height = `${window.scrollY + window.innerHeight}px`; }
+    /* When the <style> loaded, set hints host's size */
+    hintsStyle.onload = () => {
+        /* Get height and width in integers */
+        const height = Math.floor(document.documentElement.scrollTop +
+            document.documentElement.clientHeight) - 1;
+        const width = Math.floor(document.documentElement.scrollLeft +
+            document.documentElement.clientWidth) - 1;
+
+        /* Set height and width */
+        hintsHost.style.height = `${height}px`;
+        hintsHost.style.width = `${width}px`;
+    }
 
     hintsHost.shadowRoot.appendChild(hintsStyle);
     const regionalHints = createRegionalHints(clipboard);

--- a/src/content_scripts/content.css
+++ b/src/content_scripts/content.css
@@ -3,8 +3,10 @@ div.surfingkeys_hints_host {
     opacity: 1;
     color-scheme: auto;
     position: absolute;
-    inset: 0 0 auto 0;
-    overflow: visible;
+    top: 0;
+    left: 0;
+    overflow: hidden;
+    pointer-events: none;
 }
 div.surfingkeys_match_mark {
     background-color: #ff0;


### PR DESCRIPTION
Closes #2304
- The hints host get the height and the width of the visible user's viewport (instead of the only height before that)
- Width and height are now taken without considering the scrollbar and without floating point values
- You can mouse click through the hints host (`pointer-events: none`)