### PR TITLE
add keybinding-emacs of ace-builds

### DIFF
--- a/src/content_scripts/ace.js
+++ b/src/content_scripts/ace.js
@@ -1,5 +1,6 @@
 import "ace-builds/src-noconflict/ace";
 import "ace-builds/src-noconflict/ext-language_tools";
 import "ace-builds/src-noconflict/keybinding-vim";
+import "ace-builds/src-noconflict/keybinding-emacs";
 import "ace-builds/src-noconflict/mode-javascript";
 import "ace-builds/src-noconflict/theme-chrome";


### PR DESCRIPTION
This import makes ace emacs keybindings work for me.