### PR TITLE
feat(commands): Allow users to define custom omnibar commands

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -104,6 +104,9 @@
 *   [RUNTIME][100]
     *   [Parameters][101]
     *   [Examples][102]
+*   [addCommand][103]
+    *   [Parameters][104]
+    *   [Examples][105]
 
 ## mapkey
 
@@ -702,6 +705,24 @@ RUNTIME('getTabs', {queryInfo: {currentWindow: true}}, response => {
 });
 ```
 
+## addCommand
+
+Add a command into Omnibar.
+
+### Parameters
+
+*   `name` **[string][103]** the name of the command, used as command name in omnibar.
+*   `description` **[string][103]** a help message to describe the command.
+*   `jscode` **[function][104]** a Javascript function to be bound. If the command receives an argument, the argument will be passed to the function.
+
+### Examples
+
+```javascript
+addCommand("example", "An example command", function(arg) {
+    console.log("You entered: " + arg);
+});
+```
+
 [1]: #mapkey
 
 [2]: #parameters
@@ -906,22 +927,28 @@ RUNTIME('getTabs', {queryInfo: {currentWindow: true}}, response => {
 
 [102]: #examples-23
 
-[103]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
+[103]: #addcommand
 
-[104]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
+[104]: #parameters-38
 
-[105]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
+[105]: #examples-24
 
-[106]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
+[106]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
 
-[107]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
+[107]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
 
-[108]: https://developer.mozilla.org/docs/Web/HTML/Element
+[108]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
 
-[109]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
+[109]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
 
-[110]: https://github.com/brookhong/Surfingkeys/wiki/Register-inline-query
+[110]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
 
-[111]: https://developer.mozilla.org/docs/Web/API/Element
+[111]: https://developer.mozilla.org/docs/Web/HTML/Element
 
-[112]: https://github.com/ajaxorg/ace/blob/ec450c03b51aba3724cf90bb133708078d1f3de6/lib/ace/keyboard/vim.js#L927-L1099
+[112]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
+
+[113]: https://github.com/brookhong/Surfingkeys/wiki/Register-inline-query
+
+[114]: https://developer.mozilla.org/docs/Web/API/Element
+
+[115]: https://github.com/ajaxorg/ace/blob/ec450c03b51aba3724cf90bb133708078d1f3de6/lib/ace/keyboard/vim.js#L927-L1099

--- a/src/content_scripts/front.js
+++ b/src/content_scripts/front.js
@@ -494,6 +494,13 @@ function createFront(insert, normal, hints, visual, browser) {
                 vimKeyMap
             });
         },
+        addCommand: (name, description) => {
+            applyUICommand({
+                action: 'addCommand',
+                name: name,
+                description: description
+            });
+        },
         highlightElement,
         hidePopup,
         openFinder: () => {
@@ -659,6 +666,10 @@ function createFront(insert, normal, hints, visual, browser) {
 
     _actions["emptySelection"] = function(message) {
         visual.emptySelection();
+    };
+
+    _actions["executeUserCommand"] = function(message) {
+        dispatchSKEvent('user', ['executeUserCommand', message.name, message.args]);
     };
 
     var _active = window === top;

--- a/src/content_scripts/ui/frontend.js
+++ b/src/content_scripts/ui/frontend.js
@@ -454,6 +454,16 @@ const Front = (function() {
     _actions['addVimKeyMap'] = function (message) {
         self.vimKeyMap = message.vimKeyMap;
     };
+    _actions['addCommand'] = function(message) {
+        const proxyAction = (...args) => {
+            self.contentCommand({
+                action: 'executeUserCommand',
+                name: message.name,
+                args: args
+            });
+        };
+        omnibar.command(message.name, message.description, proxyAction);
+    };
     _actions['getUsage'] = function (message) {
         // send response in callback from buildUsage
         delete message.ack;

--- a/src/user_scripts/index.js
+++ b/src/user_scripts/index.js
@@ -50,6 +50,12 @@ function vmapkey(keys, annotation, jscode, options) {
    }
 }
 
+const userDefinedCommands = {};
+function addCommand(name, description, action) {
+    userDefinedCommands[name] = action;
+    dispatchSKEvent('front', ['addCommand', name, description]);
+}
+
 function map(new_keystroke, old_keystroke, domain, new_annotation) {
     dispatchSKEvent('api', ['map', new_keystroke, old_keystroke, domain, new_annotation]);
 }
@@ -74,6 +80,11 @@ initSKFunctionListener("user", {
     callUserFunction: (keys, para) => {
         if (userDefinedFunctions.hasOwnProperty(keys)) {
             userDefinedFunctions[keys](para);
+        }
+    },
+    executeUserCommand: (name, args) => {
+        if (userDefinedCommands.hasOwnProperty(name)) {
+            userDefinedCommands[name](...args);
         }
     },
     getSearchSuggestions: (url, response, request, callbackId, origin) => {
@@ -138,6 +149,7 @@ const api = {
     aceVimMap,
     addVimMapKey,
     addSearchAlias,
+    addCommand,
     cmap,
     imap,
     imapkey,


### PR DESCRIPTION
Allow users to define their own custom commands for omnibar.

Useful for less frequent actions where a dedicated keybinding would be overkill.

- Implement a new `addCommand` API.
- Update documentation.

```
api.addCommand("test", "this is a test command", (arg) => {
  api.Front.showPopup(arg);
});
```