### PR TITLE
feat(omnibar): support initial query and enhance alias expansion

### DIFF
--- a/src/content_scripts/ui/omnibar.js
+++ b/src/content_scripts/ui/omnibar.js
@@ -1046,6 +1046,9 @@ function OpenURLs(prompt, omnibar, queryFn) {
         });
     };
     self.onOpen = function(arg) {
+        if (arg) {
+            omnibar.input.value = arg;
+        }
         sequenceNumber = 0;
         queryAndList();
     };


### PR DESCRIPTION
This PR adds two omnibar features:

- Initial query support for `URLs` type, and
- Improved alias expansion to only consider the part of input before cursor on spacebar press.

These two changes work together to allow opening the omnibar with a selection from page, move the cursor to the beginning, and type an alias to act on that selection.

It offers a different approach than having to specify one search alias with a key (i.e. `sg`).

```
api.mapkey('t', '#8Open a URL', () => {
  api.Front.openOmnibar({type: 'URLs', extra: window.getSelection().toString()});
});
```