### PR TITLE
fix: support media query for color schemes

### DIFF
--- a/src/content_scripts/uiframe.js
+++ b/src/content_scripts/uiframe.js
@@ -7,7 +7,7 @@ function createUiHost(browser, onload) {
     var uiHost = document.createElement("div");
     uiHost.style.display = "block";
     uiHost.style.opacity = 1;
-    uiHost.style.colorScheme = "light";
+    uiHost.style.colorScheme = "auto";
     var frontEndURL = chrome.runtime.getURL('pages/frontend.html');
     var ifr = document.createElement("iframe");
     ifr.setAttribute('allowtransparency', true);


### PR DESCRIPTION
This enables `@media (prefers-color-scheme: dark)` in `settings.theme`.

When `uiHost.style.colorScheme` is undefined, or set to "normal", the iframe can also follow the system theme but shows an white background when switching to dark mode. Setting it to "auto" avoids this issue.