### PR TITLE
fix(hints): restore array-based hint creation functionality

### DIFF
--- a/src/content_scripts/common/hints.js
+++ b/src/content_scripts/common/hints.js
@@ -489,6 +489,10 @@ div.hint-scrollable {
         behaviours = {
             mouseEvents: MOUSE_EVENTS
         };
+        // Clean up temporary class added for array-based hint creation
+        document.querySelectorAll('.surfingkeys--hints--creating').forEach(function(el) {
+            el.classList.remove('surfingkeys--hints--creating');
+        });
         setSanitizedContent(holder, "");
         holder.remove();
         hintsHost.remove();

--- a/src/user_scripts/index.js
+++ b/src/user_scripts/index.js
@@ -204,6 +204,13 @@ const api = {
             dispatchSKEvent('api', ['hints:click', links, force]);
         },
         create: (cssSelector, onHintKey, attrs) => {
+            if (typeof(cssSelector) !== 'string') {
+                const hintsCreating = "surfingkeys--hints--creating";
+                if (createCssSelectorForElements(hintsCreating, cssSelector) === 0) {
+                    return false;
+                }
+                cssSelector = `.${hintsCreating}`;
+            }
             hintsFunction = onHintKey;
             dispatchSKEvent('api', ['hints:create', cssSelector, "user", attrs]);
         },


### PR DESCRIPTION
Fixes the ability to create hints from an array of DOM elements using `Hints.create([element1, element2, ...])`, which was broken because DOM elements cannot be serialized through CustomEvent.

Solution: Convert arrays of elements to CSS selectors before dispatching events, similar to how Hints.click() already works:
- Add temporary `surfingkeys--hints--creating` class to elements
- Pass CSS selector string through CustomEvent instead of elements
- Clean up temporary class when hints mode exits

This restores functionality originally added in #852

Disclosure: I used Claude Code to debug and fix this issue.