### PR TITLE
fix: holding shift key should open hint in new tab

### DIFF
--- a/src/content_scripts/common/hints.js
+++ b/src/content_scripts/common/hints.js
@@ -363,7 +363,7 @@ div.hint-scrollable {
                 mouseEventModifiers[modKey] = true;
             }
             flashPressedLink(element,() => {
-                if (tabbed && getBrowserName().startsWith("Safari")) {
+                if (tabbed) {
                     RUNTIME("openLink", {
                         tab: {
                             tabbed: tabbed,


### PR DESCRIPTION
To the best of my understanding, this behavior should not be limited to Safari. Is there a good reason that we were previously checking `getBrowserName().startsWith("Safari")`? If so, I am not sure if this change breaks some previously expected behavior.