### PR TITLE
Fetch emoji.tsv only in required cases.

### DIFF
--- a/src/content_scripts/common/cursorPrompt.js
+++ b/src/content_scripts/common/cursorPrompt.js
@@ -64,7 +64,7 @@ class CursorPrompt {
         if (this.data) {
             this.#render();
         } else if (this.fetcher) {
-            this.fetcher.then((res) => {
+            this.fetcher().then((res) => {
                 this.data = res;
                 this.#render();
             });

--- a/src/content_scripts/common/insert.js
+++ b/src/content_scripts/common/insert.js
@@ -174,14 +174,15 @@ function createInsert() {
         }
     });
 
+    const emojiURL = chrome.runtime.getURL("pages/emoji.tsv");
     const emojiPrompt = new CursorPrompt((c) => {
         const ee = c.split("\t");
         const parsedUnicodeEmoji = String.fromCodePoint.apply(null, ee[0].split(','));
         return "<div><span>{0}</span>{1}</div>".format(parsedUnicodeEmoji, ee[1]);
     }, (elm) => {
         return elm.firstElementChild.innerText;
-    }, new Promise((r) => {
-        fetch(chrome.runtime.getURL("pages/emoji.tsv"))
+    }, () => new Promise((r) => {
+        fetch(emojiURL)
             .then(res => Promise.all([res.text()]))
             .then(res => {
                 r(res[0].split("\n"));


### PR DESCRIPTION
This PR defers the request to preload `pages/emoji.tsv` (which currently occurs when *every* page is opened, even if `settings.enableEmojiInsertion = false`) until the emoji input is actually triggered.