### PR TITLE
fix: Hints.setCharacters not syncing to frontend iframe

### DIFF
--- a/src/content_scripts/common/api.js
+++ b/src/content_scripts/common/api.js
@@ -507,7 +507,12 @@ function createAPI(clipboard, insert, normal, hints, visual, front, browser) {
             dispatchMouseClick: hints.dispatchMouseClick,
             style: hints.style,
             setNumeric: hints.setNumeric,
-            setCharacters: hints.setCharacters,
+            setCharacters: function(chars) {
+                hints.setCharacters(chars);
+                if (front.setHintsCharacters) {
+                    front.setHintsCharacters(chars);
+                }
+            },
         },
         Visual: {
             style: visual.style,

--- a/src/content_scripts/front.js
+++ b/src/content_scripts/front.js
@@ -96,6 +96,12 @@ function createFront(insert, normal, hints, visual, browser) {
             alias: alias
         });
     };
+    self.setHintsCharacters = function (chars) {
+        applyUICommand({
+            action: 'setHintsCharacters',
+            characters: chars
+        });
+    };
 
     var _actions = {};
     var skCallbacks = {};

--- a/src/content_scripts/ui/frontend.js
+++ b/src/content_scripts/ui/frontend.js
@@ -441,6 +441,9 @@ const Front = (function() {
             setSanitizedContent(document.getElementById("sk_theme"), message.userSettings.theme);
         }
     };
+    _actions['setHintsCharacters'] = function (message) {
+        hints.setCharacters(message.characters);
+    };
     _actions['addMapkey'] = function (message) {
         if (message.old_keystroke in Mode.specialKeys) {
             Mode.specialKeys[message.old_keystroke].push(message.new_keystroke);


### PR DESCRIPTION
The user-configured hint characters set via api.Hints.setCharacters() were not being applied to the tab switching interface (renderTabs).

This occurred because Surfingkeys runs in two separate JavaScript execution contexts:
1. Main content script (content.js) - where user config executes
2. Frontend UI iframe (frontend.html) - where renderTabs runs

Each context creates its own independent 'hints' instance, and the setCharacters call only affected the main context.

Changes:
- Modified api.Hints.setCharacters to also sync to frontend iframe
- Added front.setHintsCharacters() to send config to frontend
- Added 'setHintsCharacters' action handler in frontend.js

This ensures hint characters are consistent across all UI contexts, including the tab overlay triggered by 'T' key.