### PR TITLE
Add a command shortcut for choosing tabs

### DIFF
--- a/src/background/start.js
+++ b/src/background/start.js
@@ -417,6 +417,13 @@ function start(browser) {
                     });
                 });
                 break;
+            case 'chooseTab':
+                getActiveTab(function(tab) {
+                    sendTabMessage(tab.id, 0, {
+                        subject: 'chooseTab'
+                    });
+                });
+                break;
             case 'closeTab':
                 getActiveTab(function(tab) {
                     chrome.tabs.remove(tab.id);

--- a/src/content_scripts/content.js
+++ b/src/content_scripts/content.js
@@ -259,6 +259,10 @@ function start(browser) {
             runtime.on('showBanner', function(msg, sender, response) {
                 showBanner(msg.message, 3000);
             });
+            runtime.on('chooseTab', function() {
+                modes.front.attach();
+                modes.front.chooseTab();
+            });
             document.addEventListener("surfingkeys:ensureFrontEnd", function(evt) {
                 modes.front.attach();
             });

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -21,6 +21,9 @@
         "closeTab": {
             "description": "Close the current tab."
         },
+        "chooseTab": {
+            "description": "Choose a tab."
+        },
         "proxyThis": {
             "description": "Toggle current site in autoproxy_hosts."
         }


### PR DESCRIPTION
Add a keyboard shortcut to choose tab. This is useful in scenario where we might have unmapped all keys in a particular website, but we still want to use the tab selector from SurfingKeys