### PR TITLE
Fix key suggestion callbacks on alias

### DIFF
--- a/src/content_scripts/front.js
+++ b/src/content_scripts/front.js
@@ -79,7 +79,7 @@ function createFront(insert, normal, hints, visual, browser) {
     var _listSuggestions = {};
     self.addSearchAlias = function (alias, prompt, url, suggestionURL, listSuggestion, options) {
         if (suggestionURL && listSuggestion) {
-            _listSuggestions[suggestionURL] = listSuggestion;
+            _listSuggestions[alias] = listSuggestion;
         }
         applyUICommand({
             action: 'addSearchAlias',
@@ -137,8 +137,8 @@ function createFront(insert, normal, hints, visual, browser) {
 
     _actions["getSearchSuggestions"] = function (message) {
         var ret = null;
-        if (_listSuggestions.hasOwnProperty(message.url)) {
-            const listSuggestion = _listSuggestions[message.url];
+        if (_listSuggestions.hasOwnProperty(message.alias)) {
+            const listSuggestion = _listSuggestions[message.alias];
             if (typeof listSuggestion === "function") {
                 ret = listSuggestion(message.response, {
                     url: message.requestUrl,
@@ -151,7 +151,7 @@ function createFront(insert, normal, hints, visual, browser) {
                         resolve(res);
                     };
 
-                    dispatchSKEvent('user', ["getSearchSuggestions", message.url, message.response, {
+                    dispatchSKEvent('user', ["getSearchSuggestions", message.alias, message.response, {
                         url: message.requestUrl,
                         query: message.query,
                     }, callbackId]);

--- a/src/content_scripts/ui/omnibar.js
+++ b/src/content_scripts/ui/omnibar.js
@@ -1231,6 +1231,7 @@ function OpenVIMarks(omnibar) {
 
 function SearchEngine(omnibar, front) {
     var self = {};
+    self.alias = undefined;
     self.aliases = {};
 
     var _pendingRequest = undefined; // timeout ID
@@ -1316,7 +1317,7 @@ function SearchEngine(omnibar, front) {
             }, function (resp) {
                 front.contentCommand({
                     action: 'getSearchSuggestions',
-                    url: self.suggestionURL,
+                    alias: self.alias,
                     query: omnibar.input.value,
                     requestUrl,
                     response: resp
@@ -1333,6 +1334,7 @@ function SearchEngine(omnibar, front) {
 
     front._actions['addSearchAlias'] = function (message) {
         self.aliases[message.alias] = {
+            alias: message.alias,
             prompt: '' + message.prompt + separatorHtml,
             url: message.url,
             suggestionURL: message.suggestionURL

--- a/src/user_scripts/index.js
+++ b/src/user_scripts/index.js
@@ -88,10 +88,10 @@ initSKFunctionListener("user", {
             userDefinedCommands[name](...args);
         }
     },
-    getSearchSuggestions: async (url, response, request, callbackId, origin) => {
-        if (functionsToListSuggestions.hasOwnProperty(url)) {
+    getSearchSuggestions: async (alias, response, request, callbackId, origin) => {
+        if (functionsToListSuggestions.hasOwnProperty(alias)) {
             try {
-                const ret = await functionsToListSuggestions[url](response, request);
+                const ret = await functionsToListSuggestions[alias](response, request);
                 dispatchSKEvent("front", [callbackId, ret]);
             } catch (e) {
                 console.error("Search suggestion callback error:", e);
@@ -138,7 +138,7 @@ function addSearchAlias(alias, prompt, search_url, search_leader_key, suggestion
     if (!/^[\u0000-\u007f]*$/.test(alias)) {
         throw `Invalid alias ${alias}, which must be ASCII characters.`;
     }
-    functionsToListSuggestions[suggestion_url] = callback_to_parse_suggestion;
+    functionsToListSuggestions[alias] = callback_to_parse_suggestion;
     dispatchSKEvent('api', ['addSearchAlias', alias, prompt, search_url, search_leader_key, suggestion_url, "user", only_this_site_key, options]);
 }
 


### PR DESCRIPTION
Multiple search engines sharing the same suggestionURL would overwrite each other's callbacks. Key by alias, which is guaranteed unique.

Depends on #2388 (will rebase this after it's merged)