### PR TITLE
Fix Alt-f imap (move forward one word)

### DIFF
--- a/src/content_scripts/common/insert.js
+++ b/src/content_scripts/common/insert.js
@@ -263,7 +263,7 @@ function createInsert() {
 
     function nextNonWord(str, dir, cur) {
         var nonWord = /\W/;
-        cur = dir > 0 ? cur : cur + dir;
+        cur = cur + dir;
         for ( ; ; ) {
             if (cur < 0) {
                 cur = 0;


### PR DESCRIPTION
Alt-f in insert mode does not move the cursor if before a non-word character (e.g. a space). This fix makes it work, like Alt-b.