### PR TITLE
chore: add missing dependencies for run jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@babel/plugin-transform-runtime": "^7.15.0",
     "@babel/preset-env": "^7.15.0",
     "@babel/preset-typescript": "^7.15.0",
+    "@babel/runtime": "^7.15.0",
     "@types/events": "^3.0.0",
     "@types/jest-image-snapshot": "^4.3.1",
     "@types/lodash": "^4.14.172",


### PR DESCRIPTION
## Summary

Add `@babel/runtime` required to run jest.

## Details

I tried building it locally, but it was missing dependencies and we couldn't run the test.

In CI, tests cannot be executed due to the same reason, so we will fix this.

(By the way, why is there no `package-lock.json`? I'll add it in a separate PR if necessary.)

## Confirmation

- Being able to run `npm run test` locally
    - However, the test itself seems to fail
- Tests can be executed with CI

## Limitation

Only development dependency, no impact on userland.
