### PR TITLE
feat(omnibar): support custom onEnter for UserURLs

### DIFF
--- a/src/content_scripts/front.js
+++ b/src/content_scripts/front.js
@@ -353,13 +353,31 @@ function createFront(insert, normal, hints, visual, browser) {
      *     Front.openOmnibar({type: "UserURLs", extra: services});
      * }, {domain: /console.amazonaws|console.aws.amazon.com/i});
      */
+    var _userURLsHasCustomOnEnter = false;
     self.openOmnibar = function(args) {
         args.action = 'openOmnibar';
+        _userURLsHasCustomOnEnter = false;
         if (args.type === "LLMChat") {
             args.extra = args.extra || {};
             args.extra.url = window.location.href.replace(/\#[^\#]*$/, '');
         }
+        if (args._hasCustomOnEnter) {
+            _userURLsHasCustomOnEnter = true;
+            delete args._hasCustomOnEnter;
+        }
         self.command(args);
+    };
+
+    _actions['userURLs_entered'] = function(message) {
+        if (_userURLsHasCustomOnEnter) {
+            _userURLsHasCustomOnEnter = false;
+            dispatchSKEvent('user', ['userURLs_onEnter', message.item, message.ctrlKey, message.shiftKey]);
+        } else {
+            RUNTIME('openLink', {
+                tab: { tabbed: message.tabbed, active: !message.ctrlKey },
+                url: message.item.url
+            });
+        }
     };
 
     var _inlineQuery = false;

--- a/src/content_scripts/ui/omnibar.js
+++ b/src/content_scripts/ui/omnibar.js
@@ -452,6 +452,7 @@ function createOmnibar(front, clipboard) {
             `<div class="title">${self.highlight(rxp, htmlEncode(b.title))} ${additional}</div><div class="url">${self.highlight(rxp, htmlEncode(safeDecodeURIComponent(b.url)))}</div>`, { "class": "text-container" }));
         li.uid = uid;
         li.url = b.url;
+        li._item = b;
         return li;
     };
 
@@ -770,7 +771,7 @@ function createOmnibar(front, clipboard) {
     self.addHandler('SearchEngine', searchEngine);
     self.addHandler('Commands', Commands(self, front));
     self.addHandler('OmniQuery', OmniQuery(self, front));
-    self.addHandler('UserURLs', OpenUserURLs(self));
+    self.addHandler('UserURLs', OpenUserURLs(self, front));
     self.addHandler('LLMChat', LLMChat(self, front));
 
     front._actions['updateOmnibarResult'] = function(message) {
@@ -1582,7 +1583,7 @@ function OmniQuery(omnibar, front) {
     return self;
 }
 
-function OpenUserURLs(omnibar) {
+function OpenUserURLs(omnibar, front) {
     var self = {
         focusFirstCandidate: true,
         prompt: `UserURLs${separatorHtml}`
@@ -1600,6 +1601,17 @@ function OpenUserURLs(omnibar) {
 
         urls = filterByTitleOrUrl(_items, query, runtime.getCaseSensitive(query));
         omnibar.listURLs(urls, false);
+    };
+    self.onEnter = function() {
+        var fi = omnibar.resultsDiv.querySelector('li.focused');
+        front.contentCommand({
+            action: 'userURLs_entered',
+            item: fi ? fi._item : { url: omnibar.input.value },
+            tabbed: this.tabbed,
+            ctrlKey: !this.activeTab,
+            shiftKey: omnibar.tabbed ^ this.tabbed,
+        });
+        return this.activeTab;
     };
     return self;
 }

--- a/src/user_scripts/index.js
+++ b/src/user_scripts/index.js
@@ -77,6 +77,7 @@ let onClipboardReadFn;
 let onEditorWriteFn;
 let userScriptTask = () => {};
 let hintsCreationResolve;
+let _pendingOnEnter = null;
 initSKFunctionListener("user", {
     callUserFunction: (keys, para) => {
         if (userDefinedFunctions.hasOwnProperty(keys)) {
@@ -130,6 +131,12 @@ initSKFunctionListener("user", {
         if (hintsCreationResolve) {
             hintsCreationResolve(found);
             hintsCreationResolve = null;
+        }
+    },
+    userURLs_onEnter: (item, ctrlKey, shiftKey) => {
+        if (_pendingOnEnter) {
+            _pendingOnEnter(item, ctrlKey, shiftKey);
+            _pendingOnEnter = null;
         }
     },
 }, true);
@@ -279,6 +286,12 @@ const api = {
             dispatchSKEvent('api', ['front:showEditor', element, type, useNeovim]);
         },
         openOmnibar: (args) => {
+            _pendingOnEnter = null;
+            if (typeof args.onEnter === 'function') {
+                _pendingOnEnter = args.onEnter;
+                args = Object.assign({}, args, { _hasCustomOnEnter: true });
+                delete args.onEnter;
+            }
             dispatchSKEvent('api', ['front:openOmnibar', args]);
         },
         showBanner,


### PR DESCRIPTION
Add support for a custom `onEnter` callback in `Front.openOmnibar` when using `type: "UserURLs"`. The callback receives the selected item and raw modifier keys (`ctrlKey`, `shiftKey`). Falls back to default URL-opening behavior when no callback is provided.

## Example

```js
// Jump to a heading on the current page
api.mapkey('gh', 'Jump to heading', () => {
    const headings = [...document.querySelectorAll('h1,h2,h3,h4,h5,h6')]
        .map(el => ({ title: el.textContent.trim(), url: '#' + el.id }));
    api.Front.openOmnibar({
        type: 'UserURLs',
        extra: headings,
        onEnter: (item, ctrlKey, shiftKey) => document.getElementById(item.url.slice(1))?.scrollIntoView(),
    });
});
```