### PR TITLE
Fix capture size in MV3 background

### DIFF
--- a/src/background/start.js
+++ b/src/background/start.js
@@ -1788,15 +1788,20 @@ function start(browser) {
         });
     };
     self.getCaptureSize = function(message, sender, sendResponse) {
-        var img = document.createElement( "img" );
-        img.onload = function() {
-            _response(message, sendResponse, {
-                width: img.width,
-                height: img.height
-            });
-        };
         chrome.tabs.captureVisibleTab(null, {format: "png"}, function(dataUrl) {
-            img.src = dataUrl;
+            fetch(dataUrl)
+                .then(function(res) {
+                    return res.blob();
+                })
+                .then(function(blob) {
+                    return createImageBitmap(blob);
+                })
+                .then(function(img) {
+                    _response(message, sendResponse, {
+                        width: img.width,
+                        height: img.height
+                    });
+                });
         });
     };
     self.deleteHistoryOlderThan = function(message, sender, sendResponse) {


### PR DESCRIPTION
## Summary
- Replace DOM-based image decoding in getCaptureSize with fetch + createImageBitmap
- Avoid using document in the MV3 service worker background context

## Verification
- Ran npm run build:dev successfully
- Confirmed the generated Chrome background bundle no longer uses document.createElement("img") in getCaptureSize

Fixes the screenshot error: ReferenceError: document is not defined