### PR TITLE
feat(firefox): support policy-driven Surfingkeys defaults via managed storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Surfingkeys is doing its best to make full use of keyboard for web browsing, but
 * [Markdown preview](#markdown-preview)
 * [Capture page](#capture-page)
 * [PDF viewer](#pdf-viewer)
+* [Managed settings by browser policy (Firefox/LibreWolf)](#managed-settings-by-browser-policy-firefoxlibrewolf)
 * [Edit your own settings](#edit-your-own-settings)
 * [License](#license)
 
@@ -493,6 +494,27 @@ Remember that in insert mode, press `Ctrl-i` to open the vim editor.
 ### Edit settings
 
 `;e` to open settings editor, `:w` to save settings.
+
+### Managed settings by browser policy (Firefox/LibreWolf)
+
+Surfingkeys can read managed config from `browser.storage.managed`.
+This enables declarative setup through Firefox/LibreWolf enterprise policy.
+
+Managed keys (minimal schema):
+
+- `snippets`: inline JavaScript settings string.
+- `localPath`: URL or filesystem path to a settings file.
+  - plain paths are normalized to `file:///...`.
+
+Behavior:
+
+- managed values act as fallback defaults.
+- if user saves `snippets` or `localPath`, user values win.
+- loading settings from URL in the UI is always allowed.
+
+If both `snippets` and `localPath` exist in managed policy, `snippets` wins.
+
+See [docs/managed_settings.md](docs/managed_settings.md) for examples.
 
 ## Dot to repeat previous action
 

--- a/docs/managed_settings.md
+++ b/docs/managed_settings.md
@@ -1,0 +1,73 @@
+# Managed Surfingkeys settings (Firefox / LibreWolf)
+
+Surfingkeys supports declarative configuration through Firefox managed storage (`browser.storage.managed`).
+
+This is useful when you want a reproducible baseline from `policies.json`, while still allowing users to customize settings manually.
+
+## Policy location
+
+Managed data comes from enterprise policy:
+
+- `policies.json` → `policies` → `3rdparty` → `Extensions` → `<extension-id>`
+
+## Supported keys (minimal schema)
+
+Surfingkeys reads only these keys:
+
+- `snippets` (string)
+  - Inline Surfingkeys settings JavaScript.
+- `localPath` (string)
+  - URL or filesystem path to a settings file.
+  - Plain filesystem paths are normalized to `file:///...`.
+
+If both `snippets` and `localPath` are present, `snippets` is used.
+
+## Runtime behavior
+
+1. Managed values are fallback defaults.
+2. User-saved `snippets` / `localPath` always win.
+3. Users can always update settings manually in the UI.
+4. "Load settings from URL" remains available.
+
+## Example policies
+
+> Replace `<extension-id>` with your Surfingkeys extension ID.
+> AMO Firefox build commonly uses `{a8332c60-5b6d-41ee-bfc8-e9bb331d34ad}`.
+
+### Managed inline snippets
+
+```json
+{
+  "policies": {
+    "3rdparty": {
+      "Extensions": {
+        "<extension-id>": {
+          "snippets": "settings.scrollStepSize = 120; settings.tabsMRUOrder = true;"
+        }
+      }
+    }
+  }
+}
+```
+
+### Managed local file/path
+
+```json
+{
+  "policies": {
+    "3rdparty": {
+      "Extensions": {
+        "<extension-id>": {
+          "localPath": "/home/user/.config/surfingkeys/config.js"
+        }
+      }
+    }
+  }
+}
+```
+
+## Notes
+
+- Managed config is read-only from the extension side.
+- This feature intentionally stays small: no aliases, no wrappers, no mode flags, no integrity schema.
+- The goal is clear behavior and easy maintenance.

--- a/src/background/firefox.js
+++ b/src/background/firefox.js
@@ -4,10 +4,62 @@ import {
     start
 } from './start.js';
 
+function normalizeSettingsPath(path) {
+    path = path || "";
+    if (path.length && !/^\w+:\/\/\w+/i.test(path) && path.indexOf('file:///') === -1) {
+        path = path.replace(/\\/g, '/');
+        if (path[0] === '/') {
+            path = path.substr(1);
+        }
+        path = "file:///" + path;
+    }
+    return path;
+}
+
+// Keep Firefox managed settings intentionally small:
+// - snippets: inline JS config
+// - localPath: URL or filesystem path to fetch JS config from
+function normalizeManagedSettings(rawManagedSettings) {
+    if (!rawManagedSettings || typeof(rawManagedSettings) !== "object") {
+        return null;
+    }
+
+    var managedSet = {};
+
+    if (typeof(rawManagedSettings.snippets) === "string") {
+        managedSet.snippets = rawManagedSettings.snippets;
+    }
+
+    if (typeof(rawManagedSettings.localPath) === "string") {
+        managedSet.localPath = normalizeSettingsPath(rawManagedSettings.localPath.trim());
+    }
+
+    if (!managedSet.hasOwnProperty("snippets") && !managedSet.hasOwnProperty("localPath")) {
+        return null;
+    }
+
+    return managedSet;
+}
+
+// Read managed policy values from Firefox enterprise policy storage.
+function loadManagedSettings(cb) {
+    if (!chrome.storage || !chrome.storage.managed || !chrome.storage.managed.get) {
+        cb(null);
+        return;
+    }
+
+    chrome.storage.managed.get(null, function(rawManagedSettings) {
+        if (chrome.runtime.lastError) {
+            cb(null);
+            return;
+        }
+        cb(normalizeManagedSettings(rawManagedSettings));
+    });
+}
+
 function loadRawSettings(keys, cb, defaultSet) {
     var rawSet = defaultSet || {};
     chrome.storage.local.get(null, function(localSet) {
-        var localSavedAt = localSet.savedAt || 0;
         extendObject(rawSet, localSet);
         var subset = getSubSettings(rawSet, keys);
         if (chrome.runtime.lastError) {
@@ -53,6 +105,8 @@ start({
     detectTabTitleChange: true,
     getLatestHistoryItem,
     loadRawSettings,
+    loadManagedSettings,
+    normalizeSettingsPath,
     _applyProxySettings,
     _setNewTabUrl,
     _getContainerName

--- a/src/background/start.js
+++ b/src/background/start.js
@@ -257,6 +257,110 @@ function start(browser) {
         }
     }
 
+    // Cached copy of policy-managed settings for this extension session.
+    var managedSettings = null;
+    var managedSettingsLoaded = false;
+
+    // Normalize plain filesystem paths so Surfingkeys can read local files
+    // consistently in Firefox (file:///...).
+    function normalizeSettingsPath(path) {
+        path = path || "";
+        if (typeof(browser.normalizeSettingsPath) === "function") {
+            return browser.normalizeSettingsPath(path);
+        }
+        if (path.length && !/^\w+:\/\/\w+/i.test(path) && path.indexOf('file:///') === -1) {
+            path = path.replace(/\\/g, '/');
+            if (path[0] === '/') {
+                path = path.substr(1);
+            }
+            path = "file:///" + path;
+        }
+        return path;
+    }
+
+    // Load managed policy settings once per extension startup.
+    // The Firefox backend provides browser.loadManagedSettings.
+    function loadManagedSettings(cb) {
+        if (managedSettingsLoaded) {
+            cb(managedSettings);
+            return;
+        }
+
+        if (typeof(browser.loadManagedSettings) === "function") {
+            browser.loadManagedSettings(function(nextManagedSettings) {
+                managedSettingsLoaded = true;
+                managedSettings = nextManagedSettings || null;
+                cb(managedSettings);
+            });
+            return;
+        }
+
+        // Non-Firefox backends: no managed settings support.
+        managedSettingsLoaded = true;
+        cb(null);
+    }
+
+    // If localPath is set, fetch snippet text from that path.
+    // This is shared by user-defined localPath and managed localPath.
+    function resolveSnippetsFromPath(set, cb) {
+        if (!set.localPath) {
+            cb(set);
+            return;
+        }
+
+        request(appendNonce(set.localPath), function(resp) {
+            set.snippets = resp;
+            cb(set);
+        }, undefined, undefined, function () {
+            set.error = "Failed to read snippets from " + set.localPath;
+            cb(set);
+        });
+    }
+
+    // Apply managed policy for snippets/localPath as fallback defaults.
+    // User-saved snippets/localPath always win.
+    function applyManagedSettings(set, cb) {
+        loadManagedSettings(function(currentManagedSettings) {
+            if (!currentManagedSettings) {
+                resolveSnippetsFromPath(set, cb);
+                return;
+            }
+
+            const hasUserSnippets = set.snippets !== undefined;
+            const hasUserLocalPath = set.localPath !== undefined;
+            const hasManagedSnippets = currentManagedSettings.hasOwnProperty("snippets");
+            const hasManagedLocalPath = currentManagedSettings.hasOwnProperty("localPath");
+
+            set.managedSettings = {
+                snippets: hasManagedSnippets,
+                localPath: hasManagedLocalPath,
+                applied: null
+            };
+
+            if (hasUserSnippets || hasUserLocalPath) {
+                resolveSnippetsFromPath(set, cb);
+                return;
+            }
+
+            // Prefer managed snippets over managed localPath when both exist.
+            if (hasManagedSnippets) {
+                set.snippets = currentManagedSettings.snippets;
+                set.managedSettings.applied = "snippets";
+                cb(set);
+                return;
+            }
+
+            if (hasManagedLocalPath) {
+                set.localPath = currentManagedSettings.localPath;
+                set.managedSettings.applied = "localPath";
+                resolveSnippetsFromPath(set, cb);
+                return;
+            }
+
+            resolveSnippetsFromPath(set, cb);
+        });
+    }
+
     function loadSettings(keys, cb) {
         var tmpSet = {
             blocklist: {},
@@ -274,15 +378,18 @@ function start(browser) {
                 set.proxy = [set.proxy];
                 set.autoproxy_hosts = [set.autoproxy_hosts];
             }
-            if (set.localPath) {
-                request(appendNonce(set.localPath), function(resp) {
-                    set.snippets = resp;
-                    cb(set);
-                }, undefined, undefined, function (po) {
-                    // failed to read snippets from localPath
-                    set.error = "Failed to read snippets from " + set.localPath;
-                    cb(set);
-                });
+
+            // Resolve snippets when callers request snippet sources or managed status.
+            const shouldResolveSnippets = !keys
+                || keys === "localPath"
+                || keys === "snippets"
+                || (keys instanceof Array
+                    && (keys.indexOf("localPath") !== -1
+                        || keys.indexOf("snippets") !== -1
+                        || keys.indexOf("managedSettings") !== -1));
+
+            if (shouldResolveSnippets) {
+                applyManagedSettings(set, cb);
             } else {
                 cb(set);
             }
@@ -650,6 +757,7 @@ function start(browser) {
     }
 
     function _loadSettingsFromUrl(url, cb) {
+        url = normalizeSettingsPath(url);
         request(appendNonce(url), function(resp) {
             _updateAndPostSettings({localPath: url, snippets: resp});
             registerUserScript(resp, () => {
@@ -1328,6 +1436,8 @@ function start(browser) {
     }
     self.updateSettings = function(message, sender, sendResponse) {
         let error = "";
+        message.settings = message.settings || {};
+
         if (message.scope === "snippets") {
             // For settings from snippets, don't broadcast the update
             // neither persist into storage
@@ -1365,6 +1475,10 @@ function start(browser) {
             }
             return { error };
         } else {
+            if (Object.keys(message.settings).length === 0) {
+                return { error };
+            }
+
             if (message.settings.showAdvanced && isMV3) {
                 if (isUserScriptsAvailable()) {
                     chrome.userScripts.configureWorld({
@@ -1372,12 +1486,21 @@ function start(browser) {
                         messaging: true
                     });
                     _updateAndPostSettings(message.settings);
-                    registerUserScript(message.settings.snippets, () => {
-                        _response(message, sendResponse, { error });
-                    });
+                    if (message.settings.hasOwnProperty("snippets")) {
+                        registerUserScript(message.settings.snippets, () => {
+                            _response(message, sendResponse, { error });
+                        });
+                    } else {
+                        loadSettings(["snippets"], function(data) {
+                            registerUserScript(data.snippets, () => {
+                                _response(message, sendResponse, { error });
+                            });
+                        });
+                    }
                     return;
                 } else {
-                    error = "Advanced mode is only available when Developer mode is turned on from chrome://extensions/.";
+                    const advancedError = "Advanced mode is only available when Developer mode is turned on from chrome://extensions/.";
+                    error = error ? `${error} ${advancedError}` : advancedError;
                 }
             } else {
                 _updateAndPostSettings(message.settings);


### PR DESCRIPTION
## Summary

This PR adds a minimal declarative configuration path for Surfingkeys on Firefox/LibreWolf using enterprise managed storage (`browser.storage.managed`).

The design is simple:

- managed config provides **fallback defaults**
- users can always override settings manually in Surfingkeys

## Why

Users want reproducible setup from `policies.json` without rebuilding the extension and without locking personal customization.

## What this PR adds

### Managed keys (Firefox/LibreWolf)

- `snippets` (inline settings JS string)
- `localPath` (URL or filesystem path to settings JS)

Plain filesystem paths are normalized to `file:///...`.

### Runtime behavior

- If user-saved `snippets` or `localPath` exists, user values win.
- If user values are missing, managed values are used as defaults.
- If both managed `snippets` and `localPath` exist, `snippets` wins.
- Users can always:
  - edit settings in UI
  - use “load settings from URL”

## Architecture

- `src/background/firefox.js`
  - reads and normalizes managed policy data from Firefox storage
- `src/background/start.js`
  - applies managed values in shared settings flow (default-only precedence)

`start.js` handles precedence because it is where all settings load/update logic already lives.

## Docs

- Updated README section:
  - **Managed settings by browser policy (Firefox/LibreWolf)**
- Added:
  - `docs/managed_settings.md`
  - includes policy location, supported keys, behavior, and examples

## Validation

- `npm run build:dev`