### PR TITLE
feat: add `api.addBlocklistOrigins` / `removeBlocklistOrigins` / `getBlocklist`

### DIFF
--- a/src/background/start.js
+++ b/src/background/start.js
@@ -549,6 +549,31 @@ function start(browser) {
         }
         return "enabled";
     }
+    self.addBlocklistOrigins = function(message, sender, sendResponse) {
+        loadSettings('blocklist', function(data) {
+            message.origins.forEach(function(origin) {
+                data.blocklist[origin] = 1;
+            });
+            _updateAndPostSettings({blocklist: data.blocklist}, function() {
+                _response(message, sendResponse, {blocklist: data.blocklist});
+            });
+        });
+    };
+    self.removeBlocklistOrigins = function(message, sender, sendResponse) {
+        loadSettings('blocklist', function(data) {
+            message.origins.forEach(function(origin) {
+                delete data.blocklist[origin];
+            });
+            _updateAndPostSettings({blocklist: data.blocklist}, function() {
+                _response(message, sendResponse, {blocklist: data.blocklist});
+            });
+        });
+    };
+    self.getBlocklist = function(message, sender, sendResponse) {
+        loadSettings('blocklist', function(data) {
+            _response(message, sendResponse, {blocklist: data.blocklist});
+        });
+    };
     self.toggleBlocklist = function(message, sender, sendResponse) {
         loadSettings('blocklist', function(data) {
             var origin = ".*";

--- a/src/content_scripts/common/api.js
+++ b/src/content_scripts/common/api.js
@@ -494,6 +494,15 @@ function createAPI(clipboard, insert, normal, hints, visual, front, browser) {
         tabOpenLink,
         vmap,
         vmapkey,
+        addBlocklistOrigins: (origins, cb) => {
+            RUNTIME('addBlocklistOrigins', {origins: origins}, cb);
+        },
+        removeBlocklistOrigins: (origins, cb) => {
+            RUNTIME('removeBlocklistOrigins', {origins: origins}, cb);
+        },
+        getBlocklist: (cb) => {
+            RUNTIME('getBlocklist', {}, cb);
+        },
         Clipboard: clipboard,
         Normal: {
             feedkeys: normal.feedkeys,

--- a/src/user_scripts/index.js
+++ b/src/user_scripts/index.js
@@ -192,6 +192,15 @@ const api = {
     unmapAllExcept: (keystrokes, domain) => {
         dispatchSKEvent('api', ['unmapAllExcept', keystrokes, domain]);
     },
+    addBlocklistOrigins: (origins, cb) => {
+        RUNTIME('addBlocklistOrigins', {origins: origins}, cb);
+    },
+    removeBlocklistOrigins: (origins, cb) => {
+        RUNTIME('removeBlocklistOrigins', {origins: origins}, cb);
+    },
+    getBlocklist: (cb) => {
+        RUNTIME('getBlocklist', {}, cb);
+    },
     readText: (text, options) => {
         dispatchSKEvent('api', ['readText', text, options]);
     },


### PR DESCRIPTION
## Summary

Adds three small API functions that let a user snippet add or remove arbitrary origins from the existing persistent blocklist (`set.blocklist` in background storage, the same one that the `Alt-s` / `Ctrl-Alt-S` toggle writes to).

The intent is to give users a snippet-level workaround for sites where snippets themselves cannot run, most notably Google Docs and Google Slides (see #2428). Because the existing blocklist check in `_getState` uses the top frame's URL via `getSenderUrl`, a programmatic entry written from any non-blocked page will correctly disable Surfingkeys on Docs / Slides, including inside their `about:blank` editor iframes, which is what makes other approaches (`unmapAllExcept`, `blocklistPattern`, `lurkingPattern`) currently fail there.

## Example usage

```js
api.addBlocklistOrigins([
    'https://docs.google.com',
    'https://slides.google.com',
    'https://sheets.google.com',
]);
```

The snippet runs whenever the user visits any non-blocked page. The origins are persisted in `chrome.storage`, so they apply on the next visit to Docs / Slides and survive browser restarts.

## Changes

Three new background message handlers in `src/background/start.js`:

- `addBlocklistOrigins({origins: string[]})` - adds origins that aren't already present, never removes.
- `removeBlocklistOrigins({origins: string[]})` 0 removes origins that are present.
- `getBlocklist()` - returns the current blocklist object.

All three reuse the existing `loadSettings('blocklist', ...)` / `_updateAndPostSettings({blocklist: ...})` plumbing, so they go through the same persistence, broadcast and state-recomputation paths as the existing `toggleBlocklist`.

Thin wrappers exposed in `src/user_scripts/index.js` (MV3 user-script entry) and `src/content_scripts/common/api.js` (the in-frame API used in MV2 and in chrome-extension URL contexts) so snippets can call `api.addBlocklistOrigins([...])` directly.

## Backwards compatibility

No behavior changes for existing users:
- The default config still has whatever was in `set.blocklist` before; this PR only adds new ways to write to it.
- No new permissions in `manifest.json`.
- The three new handlers are additive; no existing handler signatures change.

Workaround for #2428, #2226, #2310
