### PR TITLE
fix(scroll): ignore invisible and non-user-scrollable elements

### DIFF
--- a/src/content_scripts/common/mode.js
+++ b/src/content_scripts/common/mode.js
@@ -2,6 +2,7 @@ import {
     listElements,
     isInUIFrame,
     reportIssue,
+    isElementDrawn,
 } from './utils.js';
 import { RUNTIME, dispatchSKEvent, runtime } from './runtime.js';
 import KeyboardUtils from './keyboardUtils';
@@ -179,6 +180,15 @@ function init(cb) {
 }
 
 Mode.hasScroll = function (el, direction, barSize) {
+    const style = window.getComputedStyle(el);
+    if (!style) {
+        return false;
+    }
+    const overflow = (direction === 'y') ? style.overflowY : style.overflowX;
+    if (!['auto', 'scroll', 'overlay'].includes(overflow)) {
+        return false;
+    }
+
     var offset = (direction === 'y') ? ['scrollTop', 'height'] : ['scrollLeft', 'width'];
     var result = el[offset[0]];
 
@@ -198,7 +208,7 @@ Mode.hasScroll = function (el, direction, barSize) {
 
 Mode.getScrollableElements = function () {
     var nodes = listElements(document.body, NodeFilter.SHOW_ELEMENT, function(n) {
-        return (Mode.hasScroll(n, 'y', 16) && n.scrollHeight > 200 ) || (Mode.hasScroll(n, 'x', 16) && n.scrollWidth > 200);
+        return isElementDrawn(n) && ((Mode.hasScroll(n, 'y', 16) && n.scrollHeight > 200 ) || (Mode.hasScroll(n, 'x', 16) && n.scrollWidth > 200));
     });
     nodes.sort(function(a, b) {
         if (b.contains(a)) return 1;


### PR DESCRIPTION
## Problem

Currently, invisible elements and elements styled with overflow: hidden/visible are falsely captured as scroll targets. But they aren't really scrollable.

## Solution

1. Filter by visibility: Added `isElementDrawn(n)` to `Mode.getScrollableElements()` to filter out invisible/collapsed elements.
2. Filter by `overflow`: Updated `Mode.hasScroll()` to reject elements unless their computed overflow is `auto`, `scroll`, or `overlay`.