### PR TITLE
fix: set `copy` property for omnibar items

### DIFF
--- a/src/content_scripts/ui/omnibar.js
+++ b/src/content_scripts/ui/omnibar.js
@@ -452,6 +452,7 @@ function createOmnibar(front, clipboard) {
             `<div class="title">${self.highlight(rxp, htmlEncode(b.title))} ${additional}</div><div class="url">${self.highlight(rxp, htmlEncode(safeDecodeURIComponent(b.url)))}</div>`, { "class": "text-container" }));
         li.uid = uid;
         li.url = b.url;
+        li.copy = b.copy;
         li._item = b;
         return li;
     };


### PR DESCRIPTION
The callback of `ctrl-c` in omnibar currently uses a `copy` property in favor of `url`.

https://github.com/brookhong/Surfingkeys/blob/1be5c6cf10ced24988371b368aeb56692408b790/src/content_scripts/ui/omnibar.js#L169-L191

But this property is never set for items. This commit fixes it.

Now user can set an alternate string than `url` to copy with `ctrl-c`.