### PR TITLE
fix(hints): handle RegExp args and reconstitute textAnchorPat

### DIFF
--- a/src/content_scripts/common/api.js
+++ b/src/content_scripts/common/api.js
@@ -431,7 +431,13 @@ function createAPI(clipboard, insert, normal, hints, visual, front, browser) {
             });
         },
         "hints:click": hints.click,
-        "hints:create": hints.create,
+        "hints:create": (cssSelector, onHintKey, attrs) => {
+            if (cssSelector && cssSelector.source !== undefined && !(cssSelector instanceof RegExp)) {
+                // A regex forwarded from the user-script world arrives as {source, flags}.
+                cssSelector = new RegExp(cssSelector.source, cssSelector.flags);
+            }
+            return hints.create(cssSelector, onHintKey, attrs);
+        },
         "hints:setCharacters": hints.setCharacters,
         "hints:setNumeric": hints.setNumeric,
         "hints:style": hints.style,

--- a/src/content_scripts/common/hints.js
+++ b/src/content_scripts/common/hints.js
@@ -460,7 +460,7 @@ div.hint-scrollable {
                     const target = elm[0];
                     // remove Text Node from elm as it cannot be transitted across JS scope
                     elm[0] = "__EVENT_TARGET__";
-                    dispatchSKEvent('user', ["onHintClicked", elm], target);
+                    dispatchSKEvent('user', ["onHintClicked", elm, shiftKey], target);
                 } else {
                     dispatchSKEvent('user', ["onHintClicked", shiftKey], elm);
                 }

--- a/src/content_scripts/common/hints.js
+++ b/src/content_scripts/common/hints.js
@@ -456,13 +456,14 @@ div.hint-scrollable {
                     _onHintKey(elm);
                 }
             } else {
+                // dispatch (element, shiftKey); the node can't cross scopes, so it rides as
+                // the event target via the "__EVENT_TARGET__" placeholder
                 if (elm.constructor.name === "Array") {
                     const target = elm[0];
-                    // remove Text Node from elm as it cannot be transitted across JS scope
                     elm[0] = "__EVENT_TARGET__";
                     dispatchSKEvent('user', ["onHintClicked", elm, shiftKey], target);
                 } else {
-                    dispatchSKEvent('user', ["onHintClicked", shiftKey], elm);
+                    dispatchSKEvent('user', ["onHintClicked", "__EVENT_TARGET__", shiftKey], elm);
                 }
             }
             if (behaviours.multipleHits) {

--- a/src/content_scripts/common/utils.js
+++ b/src/content_scripts/common/utils.js
@@ -291,9 +291,11 @@ function initSKFunctionListener(name, interfaces, capture) {
         let args = evt.detail;
         const fk = args.shift();
         if (capture) {
+            // restore the un-serializable node from evt.target into the "__EVENT_TARGET__" placeholder
             if (args.length > 0 && args[0].constructor.name === "Array" && args[0][0] === "__EVENT_TARGET__") {
-                // restore args from evt.target, see src/content_scripts/common/hints.js:442
                 args[0][0] = evt.target;
+            } else if (args.length > 0 && args[0] === "__EVENT_TARGET__") {
+                args[0] = evt.target;
             } else {
                 args.push(evt.target);
             }

--- a/src/content_scripts/content.js
+++ b/src/content_scripts/content.js
@@ -64,6 +64,7 @@ function applyRuntimeConf(normal) {
     ensureRegex("prevLinkRegex");
     ensureRegex("nextLinkRegex");
     ensureRegex("clickablePat");
+    ensureRegex("textAnchorPat");
     RUNTIME('getState', {
         blocklistPattern: runtime.conf.blocklistPattern ? runtime.conf.blocklistPattern : undefined,
         lurkingPattern: runtime.conf.lurkingPattern ? runtime.conf.lurkingPattern : undefined

--- a/src/user_scripts/index.js
+++ b/src/user_scripts/index.js
@@ -122,9 +122,16 @@ initSKFunctionListener("user", {
     onEditorWrite: (data) => {
         onEditorWriteFn(data);
     },
-    onHintClicked: (shiftKey, element) => {
-        if (typeof(hintsFunction) === 'function') {
-            hintsFunction(element, shiftKey);
+    onHintClicked: (shiftKeyOrElement, element) => {
+        if (typeof(hintsFunction) !== 'function') {
+            return;
+        }
+        if (Array.isArray(shiftKeyOrElement)) {
+            // regex / text-node hints deliver [textNode, matchIndex, matchText]
+            // as the element, followed by shiftKey (see hints.js onHintClicked dispatch).
+            hintsFunction(shiftKeyOrElement, element);
+        } else {
+            hintsFunction(element, shiftKeyOrElement);
         }
     },
     onHintCreated: (found) => {
@@ -223,7 +230,11 @@ const api = {
             dispatchSKEvent('api', ['hints:click', links, force]);
         },
         create: (cssSelector, onHintKey, attrs) => {
-            if (typeof(cssSelector) !== 'string') {
+            if (cssSelector instanceof RegExp) {
+                // Forward the pattern as a plain object; it is rebuilt into a
+                // RegExp on the content-script side (see api.js "hints:create").
+                cssSelector = { source: cssSelector.source, flags: cssSelector.flags };
+            } else if (typeof(cssSelector) !== 'string') {
                 const hintsCreating = "surfingkeys--hints--creating";
                 if (createCssSelectorForElements(hintsCreating, cssSelector) === 0) {
                     return false;

--- a/src/user_scripts/index.js
+++ b/src/user_scripts/index.js
@@ -122,16 +122,9 @@ initSKFunctionListener("user", {
     onEditorWrite: (data) => {
         onEditorWriteFn(data);
     },
-    onHintClicked: (shiftKeyOrElement, element) => {
-        if (typeof(hintsFunction) !== 'function') {
-            return;
-        }
-        if (Array.isArray(shiftKeyOrElement)) {
-            // regex / text-node hints deliver [textNode, matchIndex, matchText]
-            // as the element, followed by shiftKey (see hints.js onHintClicked dispatch).
-            hintsFunction(shiftKeyOrElement, element);
-        } else {
-            hintsFunction(element, shiftKeyOrElement);
+    onHintClicked: (element, shiftKey) => {
+        if (typeof(hintsFunction) === 'function') {
+            hintsFunction(element, shiftKey);
         }
     },
     onHintCreated: (found) => {


### PR DESCRIPTION
Two related fixes for `RegExp`-valued hint handling, which is currently broken on the MV3 path.

### `Hints.create` ignores a `RegExp` argument from user scripts

In MV3 the user config runs in a separate `USER_SCRIPT` world and reaches `Hints.create` through the proxy in `user_scripts/index.js`. That proxy only handled string selectors and element collections, so a `RegExp` fell into the element path, resolved to zero elements, and silently returned `false` before dispatching anything. The regex-to-text-node feature in `hints.js` was therefore unreachable from user config, even though the API accepts a `RegExp` directly on the MV2 in-realm path.

- Forward the `RegExp` as `{source, flags}` from the proxy and rebuild it on the content-script side in `api.js` `"hints:create"`, mirroring `ensureRegex`.
- Deliver the `[textNode, matchIndex, matchText]` array to the callback as its `element` for text-node hints (it was landing in the `shiftKey` slot, leaving `element` undefined).
- Carry `shiftKey` through the text-node dispatch so the callback receives `(element, shiftKey)`, matching the in-content contract.

### `textAnchorPat` is never reconstituted from serialized settings

Regex-valued settings can't survive serialization, so after a settings round-trip through storage they arrive as plain `{source, flags}` objects. `ensureRegex` rebuilds them into real `RegExp`s, but it was only called for `prevLinkRegex`, `nextLinkRegex`, and `clickablePat` — `textAnchorPat` was omitted.

As a result, a user-set `textAnchorPat` stayed a plain object, failed the `constructor.name === "RegExp"` check in `hints.js`, and got passed to `querySelectorAll` as `[object Object]`, throwing `'[object Object]' is not a valid selector` when initiating Visual mode. Fixed by adding `ensureRegex("textAnchorPat")` alongside the others.
