### PR TITLE
docs: add OrcaRouter as a named LLM provider example

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,7 +612,7 @@ There are several LLM providers integrated into Surfingkeys now. Use `A` to call
 
 * Ollama
 * Bedrock
-* Custom LLM provider (e.g.: SiliconFlow, OpenRouter, DeepSeek and Gemini; other OpenAI API compatible services should also work)
+* Custom LLM provider (e.g.: SiliconFlow, OpenRouter, DeepSeek, Gemini and OrcaRouter; other OpenAI API compatible services should also work)
 
 To use the feature, you need to set up your credentials/API keys first, like this:
 
@@ -647,6 +647,11 @@ To use the feature, you need to set up your credentials/API keys first, like thi
                 serviceUrl: 'https://generativelanguage.googleapis.com/v1beta/openai/chat/completions',
                 apiKey: '***********************************',
                 model: 'gemini-2.0-flash',
+            },
+            orcarouter: {
+                serviceUrl: 'https://api.orcarouter.ai/v1/chat/completions',
+                apiKey: '***********************************',
+                model: 'orcarouter/auto',
             },
         }
     };

--- a/README_CN.md
+++ b/README_CN.md
@@ -593,7 +593,7 @@ Surfingkeys默认使用[这个markdown分析器](https://github.com/chjj/marked)
 
 * Ollama
 * Bedrock
-* 自定义模型(例如：SiliconFlow、OpenRouter、DeepSeek 和 Gemini, 其他和OpenAI API兼容的服务应该也可以)
+* 自定义模型(例如：SiliconFlow、OpenRouter、DeepSeek、Gemini 和 OrcaRouter, 其他和OpenAI API兼容的服务应该也可以)
 
 使用之前，必须设置相应的密钥或者API key，比如
 
@@ -628,6 +628,11 @@ Surfingkeys默认使用[这个markdown分析器](https://github.com/chjj/marked)
                 serviceUrl: 'https://generativelanguage.googleapis.com/v1beta/openai/chat/completions',
                 apiKey: '***********************************',
                 model: 'gemini-2.0-flash',
+            },
+            orcarouter: {
+                serviceUrl: 'https://api.orcarouter.ai/v1/chat/completions',
+                apiKey: '***********************************',
+                model: 'orcarouter/auto',
             },
         }
     };


### PR DESCRIPTION
docs: add OrcaRouter as a named LLM provider example

## What

Adds OrcaRouter to the list of custom LLM provider presets in both the English and Chinese READMEs, mirroring the existing OpenRouter entry:

- `serviceUrl: 'https://api.orcarouter.ai/v1/chat/completions'`
- `model: 'orcarouter/auto'` (OrcaRouter's smart routing model, which auto-selects the best available model per request)

No code changes are needed: `src/background/llm.js` already ships a generic OpenAI-compatible client, so configuring the `orcarouter` block under `settings.llm.custom` and setting `defaultLLMProvider = "orcarouter"` works out of the box.

## Why

[OrcaRouter](https://www.orcarouter.ai) is a gateway for OpenAI-compatible chat APIs — you can bring your own keys from OpenAI, Anthropic, DeepSeek and others, and route every request through one endpoint. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Verification

- `curl -X POST https://api.orcarouter.ai/v1/chat/completions` with `model: orcarouter/auto` returned HTTP 200 with a valid completion.
- Only markdown docs changed (`README.md`, `README_CN.md`); CI build is unaffected.

Disclosure: I'm an engineer on the OrcaRouter team.
