### PR TITLE
fix: deal with configureWorld() error on load

### DIFF
--- a/src/background/start.js
+++ b/src/background/start.js
@@ -491,10 +491,12 @@ function start(browser) {
             handleMessage(m, s, r);
         });
         chrome.runtime.onInstalled.addListener((e) => {
-            chrome.userScripts.configureWorld({
-                csp: 'script-src \'self\' \'unsafe-eval\'',
-                messaging: true
-            });
+            if (isUserScriptsAvailable()) {
+                chrome.userScripts.configureWorld({
+                    csp: 'script-src \'self\' \'unsafe-eval\'',
+                    messaging: true
+                });
+            }
         });
     }
 


### PR DESCRIPTION
Loading the unpacked extension gave me this error:

    Error in event handler: TypeError: Cannot read properties of undefined (reading 'configureWorld') at chrome-extension://ohlafnoifnickmdhmfaohehllklemhlh/background.js:6:23070

This was loading from 26da40331. My browser: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36

I copied over the isUserScriptsAvailable() check from updateSettings() and it seemed to do the trick.